### PR TITLE
Remove hardcoded repo paths when posting pr comments

### DIFF
--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -114,7 +114,10 @@ func (g *GitHub) PullRequestEvent(e *github.PullRequestEvent) error {
 	}
 
 	// Post issues as comments on github pr
-	install.WriteIssues(*e.Number, *pr.Head.SHA, issues)
+	err = install.WriteIssues(*pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name, *e.Number, *pr.Head.SHA, issues)
+	if err != nil {
+		return errors.Wrapf(err, "could not write comment on %v", *pr.HTMLURL)
+	}
 
 	// Set the CI status API to success
 	if err := install.SetStatus(*pr.StatusesURL, StatusStateSuccess); err != nil {

--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -181,6 +181,9 @@ func TestPullRequestEvent(t *testing.T) {
 		expectedCmtPath = "main.go"
 		expectedCmtPos  = 1
 		expectedCmtSHA  = "error"
+		expectedOwner   = "owner"
+		expectedRepo    = "repo"
+		expectedPR      = 3
 	)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -214,7 +217,7 @@ index 0000000..6362395
 		case "/installations/2/access_tokens":
 			// respond with any token to installation transport
 			fmt.Fprintln(w, "{}")
-		case "/repos/bf-test/gopherci-dev1/pulls/1/comments":
+		case fmt.Sprintf("/repos/%v/%v/pulls/%v/comments", expectedOwner, expectedRepo, expectedPR):
 			expected := github.PullRequestComment{
 				Body:     github.String(expectedCmtBody),
 				Path:     github.String(expectedCmtPath),
@@ -254,13 +257,18 @@ index 0000000..6362395
 
 	event := &github.PullRequestEvent{
 		Action: github.String("opened"),
-		Number: github.Int(1),
+		Number: github.Int(expectedPR),
 		PullRequest: &github.PullRequest{
+			HTMLURL:     github.String("https://github.com.au/owner/repo/pulls/3"),
 			StatusesURL: github.String(ts.URL + "/status-url"),
 			DiffURL:     github.String(expectedConfig.DiffURL),
 			Base: &github.PullRequestBranch{
 				Repo: &github.Repository{
 					CloneURL: github.String(expectedConfig.BaseURL),
+					Name:     github.String(expectedRepo),
+					Owner: &github.User{
+						Login: github.String(expectedOwner),
+					},
 				},
 				Ref: github.String(expectedConfig.BaseBranch),
 			},

--- a/internal/github/installation.go
+++ b/internal/github/installation.go
@@ -91,7 +91,10 @@ func (i *Installation) SetStatus(statusURL string, status StatusState) error {
 	return nil
 }
 
-func (i *Installation) WriteIssues(prNumber int, commit string, issues []analyser.Issue) {
+// WriteIssues takes a slice of issues and creates a pull request comment for
+// each issue on a given owner, repo, pr and commit hash. Returns on the first
+// error encountered.
+func (i *Installation) WriteIssues(owner, repo string, prNumber int, commit string, issues []analyser.Issue) error {
 	// TODO make this idempotent, so don't post the same issue twice
 	// which may occur when we support additional commits to a PR (synchronize
 	// api event)
@@ -102,10 +105,10 @@ func (i *Installation) WriteIssues(prNumber int, commit string, issues []analyse
 			Path:     github.String(issue.File),
 			Position: github.Int(issue.HunkPos),
 		}
-
-		cmt, resp, err := i.client.PullRequests.CreateComment("bf-test", "gopherci-dev1", prNumber, comment)
-		log.Print("cmt:", cmt)
-		log.Print("resp:", resp)
-		log.Print("err:", err)
+		_, _, err := i.client.PullRequests.CreateComment(owner, repo, prNumber, comment)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }


### PR DESCRIPTION
This assumes some parameters are correct for organisations as well
as user repos, I'm not convinced but GitHub docs aren't clear.