### PR TITLE
GCPPubSubQueue should log closing after context closes

### DIFF
--- a/internal/queue/gcp-pubsub.go
+++ b/internal/queue/gcp-pubsub.go
@@ -83,8 +83,8 @@ func NewGCPPubSubQueue(ctx context.Context, wg *sync.WaitGroup, c chan<- interfa
 
 	// Close iterator when context closes
 	go func() {
-		log.Println("GCPPubSubQueue: closing")
 		<-q.ctx.Done()
+		log.Println("GCPPubSubQueue: closing")
 		itr.Stop()
 		client.Close()
 	}()


### PR DESCRIPTION
Not before the context closes, mistake on my behalf.