### PR TITLE
Add dominikh's gosimple, staticcheck and unused tools

### DIFF
--- a/migrations/3_tools_dominikh.sql
+++ b/migrations/3_tools_dominikh.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+INSERT INTO tools (name, url, path, args, `regexp`) VALUES
+    ("gosimple", "https://github.com/dominikh/go-tools", "gosimple", "./...", ""),
+    ("staticcheck", "https://github.com/dominikh/go-tools", "staticcheck", "./...", ""),
+    ("unused", "https://github.com/dominikh/go-tools", "unused", "./...", "");
+
+-- +migrate Down
+


### PR DESCRIPTION
This is a very special release where we're finally adding dominikh's gosimple, staticcheck and unused tools.

We're still far from having user configurable tools, but these are of high enough quality to be useful and low enough false positives that they shouldn't cause any problems being enabled globally.

We've had to make a minor change to gopherci to support a new option in revgrep, see the commit messages for more information.

Resolves #40.