### PR TITLE
Clone to import path in $GOPATH/src/

### DIFF
--- a/internal/analyser/analyser_test.go
+++ b/internal/analyser/analyser_test.go
@@ -19,7 +19,7 @@ type mockAnalyser struct {
 var _ Analyser = &mockAnalyser{}
 var _ Executer = &mockAnalyser{}
 
-func (a *mockAnalyser) NewExecuter() (Executer, error) {
+func (a *mockAnalyser) NewExecuter(_ string) (Executer, error) {
 	// Return itself
 	return a, nil
 }

--- a/internal/analyser/docker.go
+++ b/internal/analyser/docker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -61,11 +62,12 @@ type DockerExecuter struct {
 	projPath  string // path to project
 }
 
-// NewExecuter implements Analyser interface by creating and starting a container
-func (d *Docker) NewExecuter() (Executer, error) {
+// NewExecuter implements Analyser interface by creating and starting a
+// docker container.
+func (d *Docker) NewExecuter(goSrcPath string) (Executer, error) {
 	exec := &DockerExecuter{
 		client:   d.client,
-		projPath: "$GOPATH/src/gopherci",
+		projPath: filepath.Join("$GOPATH", "src", goSrcPath),
 	}
 
 	name := fmt.Sprintf("goperci-%d", time.Now().UnixNano())

--- a/internal/analyser/docker_test.go
+++ b/internal/analyser/docker_test.go
@@ -11,7 +11,7 @@ func TestDocker(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	exec, err := docker.NewExecuter()
+	exec, err := docker.NewExecuter("github.com/gopherci/gopherci")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -22,7 +22,7 @@ func TestDocker(t *testing.T) {
 	}
 
 	// Ensure current working directory is project path
-	if want := "/go/src/gopherci\n"; want != string(out) {
+	if want := "/go/src/github.com/gopherci/gopherci\n"; want != string(out) {
 		t.Errorf("\nwant %q\nhave %q", want, out)
 	}
 

--- a/internal/analyser/filesystem.go
+++ b/internal/analyser/filesystem.go
@@ -36,9 +36,9 @@ func NewFileSystem(base string) (*FileSystem, error) {
 }
 
 // NewExecuter implements the Analyser interface
-func (fs *FileSystem) NewExecuter() (Executer, error) {
+func (fs *FileSystem) NewExecuter(goSrcPath string) (Executer, error) {
 	e := &FileSystemExecuter{}
-	if err := e.mktemp(fs.base); err != nil {
+	if err := e.mktemp(fs.base, goSrcPath); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -48,16 +48,16 @@ func (fs *FileSystem) NewExecuter() (Executer, error) {
 // environment.
 type FileSystemExecuter struct {
 	gopath   string // gopath is base/$rand
-	projpath string // projpath is gopath/src/gopherci and stores the project
+	projpath string // projpath is gopath/src/<goSrcPath>
 }
 
 // Ensure FileSystemExecuter implements Executer
 var _ Executer = (*FileSystemExecuter)(nil)
 
-func (e *FileSystemExecuter) mktemp(base string) error {
+func (e *FileSystemExecuter) mktemp(base, goSrcPath string) error {
 	rand := strconv.Itoa(int(time.Now().UnixNano()))
 	e.gopath = filepath.Join(base, rand)
-	e.projpath = filepath.Join(e.gopath, "src", "gopherci")
+	e.projpath = filepath.Join(e.gopath, "src", goSrcPath)
 
 	if err := os.MkdirAll(e.projpath, 0700); err != nil {
 		return errors.Wrap(err, "fsExecuter.Mktemp: cannot mkdir")

--- a/internal/analyser/filesystem_test.go
+++ b/internal/analyser/filesystem_test.go
@@ -19,7 +19,7 @@ func TestFileSystem(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	exec, err := fs.NewExecuter()
+	exec, err := fs.NewExecuter("github.com/gopherci/gopherci")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -36,6 +36,16 @@ func TestFileSystem(t *testing.T) {
 
 	if want := gopath + " " + os.Getenv("PATH") + "\n"; want != string(out) {
 		t.Errorf("\nwant %s\nhave %s", want, out)
+	}
+
+	out, err = exec.Execute([]string{"pwd"})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Ensure current working directory is project path
+	if want := gopath + "/src/github.com/gopherci/gopherci\n"; want != string(out) {
+		t.Errorf("\nwant %q\nhave %q", want, out)
 	}
 
 	err = exec.Stop()

--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 
 	"github.com/bradleyfalzon/gopherci/internal/analyser"
 	"github.com/google/go-github/github"
@@ -101,6 +102,7 @@ func (g *GitHub) PullRequestEvent(e *github.PullRequestEvent) error {
 		HeadURL:    *pr.Head.Repo.CloneURL,
 		HeadBranch: *pr.Head.Ref,
 		DiffURL:    *pr.DiffURL,
+		GoSrcPath:  stripScheme(*pr.Base.Repo.HTMLURL),
 	}
 
 	issues, err := analyser.Analyse(g.analyser, tools, config)
@@ -127,4 +129,9 @@ func (g *GitHub) PullRequestEvent(e *github.PullRequestEvent) error {
 		return errors.Wrap(err, fmt.Sprintf("could not set status to success for %v", *pr.StatusesURL))
 	}
 	return nil
+}
+
+// stripScheme removes the scheme/protocol and :// from a URL.
+func stripScheme(url string) string {
+	return regexp.MustCompile(`[a-zA-Z0-9+.-]+://`).ReplaceAllString(url, "")
 }


### PR DESCRIPTION
Currently we clone into `$GOPATH/src/gopherci` but any project that
imports sub packages in the same repository, would have those
dependencies go get'd (go got?).

If the project imported internal packages, those couldn't be built
at all with the error `use of internal package not allowed`.

This fix attempts to guess the import path, based on the URL by:

- Getting the base repo's HTML URL `https://github.com/owner/repo`
- Strippping the scheme `github.com/owner/repo`
- Docker or file system executer runs command with that as the
working directory
- All clones, tools etc, are then executed in the repositories
working directory, which should be `$GOPATH/src/github.com/owner/repo`

I'm not a big fan of this is done (just stripping the scheme), but
the only edge case I can forsee are those with vanity import paths,
and it's not clear how to handle them right now, potentially
automated or potentially it could be configuration option per repo.

The other edgecases will come if GitHub changes URL structure or
we support other providers where the import path is not clear, both
of which can be dealt with at the time.

Fixes #16.