### PR TITLE
Add timeout to GCPPubSub connection setup

### DIFF
--- a/internal/queue/memory_test.go
+++ b/internal/queue/memory_test.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"sync"
 	"testing"
-
-	"github.com/fortytw2/leaktest"
 )
 
 func TestMemoryQueue(t *testing.T) {
-	defer leaktest.Check(t)() // ensure all goroutines exit
-
 	var (
 		ctx, cancelFunc = context.WithCancel(context.Background())
 		wg              sync.WaitGroup


### PR DESCRIPTION
There's been a couple cases now (#46) when creating the topic on
GCP Pub/Sub that has caused GopherCI to block and never start.

This change creates a context with a timeout for use by the
various pub sub sdk's setup methods with a fixed (hardcoded)
timeout. A test is also provided which sets a very low timeout and
ensures a context.DeadLineExceeded is received.

Unfortunately, a leaktest needed to be removed from an adjacent
test, which caused false positives. I did not have time to correctly
debug this situation.

Fixes #46.