### PR TITLE
Suppress writing comments after exceeding maxIssueComments

### DIFF
--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -393,16 +393,19 @@ func TestStripScheme(t *testing.T) {
 
 func TestStatusDesc(t *testing.T) {
 	tests := []struct {
-		issues []analyser.Issue
-		want   string
+		issues     []analyser.Issue
+		suppressed int
+		want       string
 	}{
-		{[]analyser.Issue{{}, {}}, "Found 2 issues"},
-		{[]analyser.Issue{{}}, "Found 1 issue"},
-		{[]analyser.Issue{}, `Found 0 issues \ʕ◔ϖ◔ʔ/`},
+		{[]analyser.Issue{{}, {}}, 2, "Found 2 issues (2 comments suppressed)"},
+		{[]analyser.Issue{{}, {}}, 1, "Found 2 issues (1 comment suppressed)"},
+		{[]analyser.Issue{{}, {}}, 0, "Found 2 issues"},
+		{[]analyser.Issue{{}}, 0, "Found 1 issue"},
+		{[]analyser.Issue{}, 0, `Found no issues \ʕ◔ϖ◔ʔ/`},
 	}
 
 	for _, test := range tests {
-		have := statusDesc(test.issues)
+		have := statusDesc(test.issues, test.suppressed)
 		if have != test.want {
 			t.Errorf("have: %v want: %v", have, test.want)
 		}

--- a/internal/github/installation_test.go
+++ b/internal/github/installation_test.go
@@ -1,0 +1,79 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/bradleyfalzon/gopherci/internal/analyser"
+	"github.com/google/go-github/github"
+)
+
+func TestWriteIssues(t *testing.T) {
+	var (
+		expectedOwner   = "owner"
+		expectedRepo    = "repo"
+		expectedPR      = 2
+		expectedCmtBody = "body"
+		expectedCmtPath = "path"
+		expectedCmtPos  = 4
+		expectedCmtSHA  = "abc123"
+		commentCount    = 0
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		decoder := json.NewDecoder(r.Body)
+		switch r.RequestURI {
+		case fmt.Sprintf("/repos/%v/%v/pulls/%v/comments", expectedOwner, expectedRepo, expectedPR):
+			expected := github.PullRequestComment{
+				Body:     github.String(expectedCmtBody),
+				Path:     github.String(expectedCmtPath),
+				Position: github.Int(expectedCmtPos),
+				CommitID: github.String(expectedCmtSHA),
+			}
+			var comment github.PullRequestComment
+			err := decoder.Decode(&comment)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(expected, comment) {
+				t.Fatalf("expected cmt:\n%#v\ngot:\n%#v", expected, comment)
+			} else {
+				commentCount++
+			}
+		default:
+			t.Logf(r.RequestURI)
+		}
+	}))
+	defer ts.Close()
+
+	i := Installation{client: github.NewClient(nil)}
+	i.client.BaseURL, _ = url.Parse(ts.URL)
+
+	// Number of issues to suppress
+	suppress := 1
+
+	// Add more issues than maxIssueComments
+	var issues []analyser.Issue
+	for n := 0; n < maxIssueComments+suppress; n++ {
+		issues = append(issues, analyser.Issue{File: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody})
+	}
+
+	suppressed, err := i.WriteIssues(expectedOwner, expectedRepo, expectedPR, expectedCmtSHA, issues)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Ensure we don't send more comments than maxIssueComments
+	if commentCount != maxIssueComments {
+		t.Errorf("commentCount %v does not match maxIssueComments %v", commentCount, maxIssueComments)
+	}
+
+	if suppressed != suppress {
+		t.Errorf("suppressed have %v want %v", suppressed, suppress)
+	}
+}


### PR DESCRIPTION
But ensure the Statuses API includes a message which states how
many comments were suppressed.

In the future, the user will be able to see all the issues on a
dedicated page, see #28.

Fixes #58.