### PR TITLE
Support GitHub PushEvent

### DIFF
--- a/internal/analyser/analyser_test.go
+++ b/internal/analyser/analyser_test.go
@@ -2,8 +2,6 @@ package analyser
 
 import (
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -35,26 +33,13 @@ func (a *mockAnalyser) Stop() error {
 	return nil
 }
 
-func TestAnalyse(t *testing.T) {
-	var diffFetched bool
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		diffFetched = true
-		fmt.Fprintln(w, `diff --git a/subdir/main.go b/subdir/main.go
-new file mode 100644
-index 0000000..6362395
---- /dev/null
-+++ b/main.go
-@@ -0,0 +1,1 @@
-+var _ = fmt.Sprintln()`)
-	}))
-	defer ts.Close()
-
+func TestAnalyse_pr(t *testing.T) {
 	cfg := Config{
-		BaseURL:    "base-url",
-		BaseBranch: "base-branch",
-		HeadURL:    "head-url",
-		HeadBranch: "head-branch",
-		DiffURL:    ts.URL,
+		EventType: EventTypePullRequest,
+		BaseURL:   "base-url",
+		BaseRef:   "base-branch",
+		HeadURL:   "head-url",
+		HeadRef:   "head-branch",
 	}
 
 	tools := []db.Tool{
@@ -62,11 +47,20 @@ index 0000000..6362395
 		{Name: "Name2", Path: "tool2"},
 	}
 
+	diff := []byte(`diff --git a/subdir/main.go b/subdir/main.go
+new file mode 100644
+index 0000000..6362395
+--- /dev/null
++++ b/main.go
+@@ -0,0 +1,1 @@
++var _ = fmt.Sprintln()`)
+
 	analyser := &mockAnalyser{
 		ExecuteOut: [][]byte{
-			{}, // git clone
-			{}, // git fetch
-			{}, // install-deps.sh
+			{},   // git clone
+			{},   // git fetch
+			diff, // git diff
+			{},   // install-deps.sh
 			[]byte(`/go/src/gopherci`),                   // pwd
 			[]byte("main.go:1: error1"),                  // tool 1
 			[]byte("/go/src/gopherci/main.go:1: error2"), // tool 2 output abs paths
@@ -86,17 +80,14 @@ index 0000000..6362395
 		t.Errorf("expected issues:\n%+v\ngot:\n%+v", expected, issues)
 	}
 
-	if !diffFetched {
-		t.Errorf("expected diff to be fetched")
-	}
-
 	if !analyser.Stopped {
 		t.Errorf("expected analyser to be stopped")
 	}
 
 	expectedArgs := [][]string{
-		{"git", "clone", "--branch", "head-branch", "--depth", "1", "--single-branch", "head-url", "."},
-		{"git", "fetch", cfg.BaseURL, cfg.BaseBranch},
+		{"git", "clone", "--depth", "1", "--branch", cfg.HeadRef, "--single-branch", cfg.HeadURL, "."},
+		{"git", "fetch", "--depth", "1", cfg.BaseURL, cfg.BaseRef},
+		{"git", "diff", fmt.Sprintf("FETCH_HEAD...%v", cfg.HeadRef)},
 		{"install-deps.sh"},
 		{"pwd"},
 		{"tool1", "-flag", "FETCH_HEAD", "./..."},
@@ -105,5 +96,80 @@ index 0000000..6362395
 
 	if !reflect.DeepEqual(analyser.Executed, expectedArgs) {
 		t.Errorf("\nhave %v\nwant %v", analyser.Executed, expectedArgs)
+	}
+}
+
+func TestAnalyse_push(t *testing.T) {
+	cfg := Config{
+		EventType: EventTypePush,
+		BaseURL:   "base-url",
+		BaseRef:   "abcde~1",
+		HeadURL:   "head-url",
+		HeadRef:   "abcde",
+	}
+
+	tools := []db.Tool{
+		{Name: "Name1", Path: "tool1", Args: "-flag %BASE_BRANCH% ./..."},
+		{Name: "Name2", Path: "tool2"},
+	}
+
+	diff := []byte(`diff --git a/subdir/main.go b/subdir/main.go
+new file mode 100644
+index 0000000..6362395
+--- /dev/null
++++ b/main.go
+@@ -0,0 +1,1 @@
++var _ = fmt.Sprintln()`)
+
+	analyser := &mockAnalyser{
+		ExecuteOut: [][]byte{
+			{},   // git clone
+			{},   // git checkout
+			diff, // git diff
+			{},   // install-deps.sh
+			[]byte(`/go/src/gopherci`),                   // pwd
+			[]byte("main.go:1: error1"),                  // tool 1
+			[]byte("/go/src/gopherci/main.go:1: error2"), // tool 2 output abs paths
+		},
+	}
+
+	issues, err := Analyse(analyser, tools, cfg)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	expected := []Issue{
+		{File: "main.go", HunkPos: 1, Issue: "Name1: error1"},
+		{File: "main.go", HunkPos: 1, Issue: "Name2: error2"},
+	}
+	if !reflect.DeepEqual(expected, issues) {
+		t.Errorf("expected issues:\n%+v\ngot:\n%+v", expected, issues)
+	}
+
+	if !analyser.Stopped {
+		t.Errorf("expected analyser to be stopped")
+	}
+
+	expectedArgs := [][]string{
+		{"git", "clone", cfg.HeadURL, "."},
+		{"git", "checkout", cfg.HeadRef},
+		{"git", "diff", fmt.Sprintf("%v...%v", cfg.BaseRef, cfg.HeadRef)},
+		{"install-deps.sh"},
+		{"pwd"},
+		{"tool1", "-flag", "abcde~1", "./..."},
+		{"tool2"},
+	}
+
+	if !reflect.DeepEqual(analyser.Executed, expectedArgs) {
+		t.Errorf("\nhave %v\nwant %v", analyser.Executed, expectedArgs)
+	}
+}
+
+func TestAnalyse_unknown(t *testing.T) {
+	cfg := Config{}
+	analyser := &mockAnalyser{}
+	_, err := Analyse(analyser, nil, cfg)
+	if err == nil {
+		t.Fatal("expected error got nil")
 	}
 }

--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/bradleyfalzon/gopherci/internal/analyser"
 	"github.com/google/go-github/github"
@@ -34,9 +35,14 @@ func (g *GitHub) WebHookHandler(w http.ResponseWriter, r *http.Request) {
 	case *github.IntegrationInstallationEvent:
 		log.Printf("github: integration event: %v, installation id: %v", *e.Action, *e.Installation.ID)
 		err = g.integrationInstallationEvent(e)
-	case *github.PullRequestEvent:
-		log.Printf("github: pull request event: %v, installation id: %v", *e.Action, *e.Installation.ID)
+	case *github.PushEvent:
+		log.Printf("github: push event: installation id: %v", *e.Installation.ID)
 		err = g.queuer.Queue(e)
+	case *github.PullRequestEvent:
+		if validPRAction(*e.Action) {
+			log.Printf("github: pull request event: %v, installation id: %v", *e.Action, *e.Installation.ID)
+			err = g.queuer.Queue(e)
+		}
 	default:
 		log.Printf("github: ignored webhook event: %T", event)
 	}
@@ -62,22 +68,70 @@ func (g *GitHub) integrationInstallationEvent(e *github.IntegrationInstallationE
 	return nil
 }
 
-// PullRequestEvent processes as Pull Request from GitHub.
-func (g *GitHub) PullRequestEvent(e *github.PullRequestEvent) error {
-	log.Printf("pr action %q on repo %v", *e.Action, *e.PullRequest.HTMLURL)
-	if !validPRAction(*e.Action) {
-		log.Printf("ignoring action %q", *e.Action)
-		return nil
+// PushEvent processes a push to a repository on GitHub.
+func PushConfig(e *github.PushEvent) analyseConfig {
+	return analyseConfig{
+		eventType:      analyser.EventTypePush,
+		installationID: *e.Installation.ID,
+		statusesURL:    strings.Replace(*e.Repo.StatusesURL, "{sha}", *e.After, -1),
+		baseURL:        *e.Repo.CloneURL,
+		// baseRef is after~numCommits to better handle forced pushes, as a
+		// forced push has the before ref of a commit that's been overwritten.
+		baseRef:   fmt.Sprintf("%v~%v", *e.After, len(e.Commits)),
+		headURL:   *e.Repo.CloneURL,
+		headRef:   *e.After,
+		goSrcPath: stripScheme(*e.Repo.HTMLURL),
 	}
+}
+
+// PullRequestEvent processes as Pull Request from GitHub.
+func PullRequestConfig(e *github.PullRequestEvent) analyseConfig {
 	pr := e.PullRequest
+	return analyseConfig{
+		eventType:      analyser.EventTypePullRequest,
+		installationID: *e.Installation.ID,
+		statusesURL:    *pr.StatusesURL,
+		baseURL:        *pr.Base.Repo.CloneURL,
+		baseRef:        *pr.Base.Ref,
+		headURL:        *pr.Head.Repo.CloneURL,
+		headRef:        *pr.Head.Ref,
+		goSrcPath:      stripScheme(*pr.Base.Repo.HTMLURL),
+		owner:          *pr.Base.Repo.Owner.Login,
+		repo:           *pr.Base.Repo.Name,
+		pr:             *e.Number,
+		sha:            *pr.Head.SHA,
+	}
+}
+
+type analyseConfig struct {
+	eventType      analyser.EventType
+	installationID int
+	statusesURL    string
+
+	// analyser
+	baseURL   string // base for pr, before for push.
+	baseRef   string // ref can be branch for pr or sha~numCommits for push.
+	headURL   string
+	headRef   string // ref can be branch for pr or sha (after) for push.
+	goSrcPath string
+
+	// issue comments, required eventType is EventTypePullRequest.
+	owner string
+	repo  string
+	pr    int
+	sha   string
+}
+
+func (g *GitHub) Analyse(cfg analyseConfig) error {
+	log.Printf("analysing config: %#v", cfg)
 
 	// Lookup installation
-	install, err := g.NewInstallation(*e.Installation.ID)
+	install, err := g.NewInstallation(cfg.installationID)
 	if err != nil {
 		return errors.Wrap(err, "error getting installation")
 	}
 	if install == nil {
-		return fmt.Errorf("could not find installation with ID %v", *e.Installation.ID)
+		return fmt.Errorf("could not find installation with ID %v", cfg.installationID)
 	}
 
 	// Find tools for this repo
@@ -87,41 +141,48 @@ func (g *GitHub) PullRequestEvent(e *github.PullRequestEvent) error {
 	}
 
 	// Set the CI status API to pending
-	err = install.SetStatus(*pr.StatusesURL, StatusStatePending, "In progress")
+	err = install.SetStatus(cfg.statusesURL, StatusStatePending, "In progress")
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("could not set status to pending for %v", *pr.StatusesURL))
+		return errors.Wrapf(err, "could not set status to pending for %v", cfg.statusesURL)
 	}
 
 	// Analyse
-	config := analyser.Config{
-		BaseURL:    *pr.Base.Repo.CloneURL,
-		BaseBranch: *pr.Base.Ref,
-		HeadURL:    *pr.Head.Repo.CloneURL,
-		HeadBranch: *pr.Head.Ref,
-		DiffURL:    *pr.DiffURL,
-		GoSrcPath:  stripScheme(*pr.Base.Repo.HTMLURL),
+	acfg := analyser.Config{
+		EventType: cfg.eventType,
+		BaseURL:   cfg.baseURL,
+		BaseRef:   cfg.baseRef,
+		HeadURL:   cfg.headURL,
+		HeadRef:   cfg.headRef,
+		GoSrcPath: cfg.goSrcPath,
 	}
 
-	issues, err := analyser.Analyse(g.analyser, tools, config)
+	issues, err := analyser.Analyse(g.analyser, tools, acfg)
 	if err != nil {
-		if err := install.SetStatus(*pr.StatusesURL, StatusStateError, "Internal error"); err != nil {
-			log.Printf("could not set status to error for %v", *pr.StatusesURL)
+		if serr := install.SetStatus(cfg.statusesURL, StatusStateError, "Internal error"); serr != nil {
+			log.Printf("could not set status to error for %v: %s", cfg.statusesURL, serr)
 		}
-		return errors.Wrap(err, fmt.Sprintf("could not analyse %v pr %v", *e.Repo.URL, *e.Number))
+		return errors.Wrap(err, "could not run analyser")
 	}
+	log.Printf("analyser found %v issues", len(issues))
 
-	// Post issues as comments on github pr
-	suppressed, err := install.WriteIssues(*pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name, *e.Number, *pr.Head.SHA, issues)
-	if err != nil {
-		return errors.Wrapf(err, "could not write comment on %v", *pr.HTMLURL)
+	// if this is a PR add comments, suppressed is the number of comments that
+	// would have been submitted if it wasn't for an internal fixed limit. For
+	// pushes, there are no comments, so suppressed is 0.
+	var suppressed = 0
+	if cfg.pr != 0 {
+		suppressed, err = install.WriteIssues(cfg.owner, cfg.repo, cfg.pr, cfg.sha, issues)
+		if err != nil {
+			return errors.Wrap(err, "could not write comment")
+		}
+		log.Printf("wrote %v issues as comments, suppressed %v", len(issues)-suppressed, suppressed)
 	}
-
-	statusDesc := statusDesc(issues, suppressed)
 
 	// Set the CI status API to success
-	if err := install.SetStatus(*pr.StatusesURL, StatusStateSuccess, statusDesc); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("could not set status to success for %v", *pr.StatusesURL))
+	statusDesc := statusDesc(issues, suppressed)
+	if err := install.SetStatus(cfg.statusesURL, StatusStateSuccess, statusDesc); err != nil {
+		return errors.Wrapf(err, "could not set status to success for %v", cfg.statusesURL)
 	}
+
 	return nil
 }
 

--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -56,6 +56,15 @@ func (a *mockAnalyser) NewExecuter(goSrcPath string) (analyser.Executer, error) 
 	return a, nil
 }
 func (a *mockAnalyser) Execute(args []string) (out []byte, err error) {
+	if len(args) > 1 && args[0] == "git" && args[1] == "diff" {
+		return []byte(`diff --git a/subdir/main.go b/subdir/main.go
+new file mode 100644
+index 0000000..6362395
+--- /dev/null
++++ b/main.go
+@@ -0,0 +1,1 @@
++var _ = fmt.Sprintln()`), nil
+	}
 	if len(args) > 0 && args[0] == "tool" {
 		return []byte(`main.go:1: error`), nil
 	}
@@ -89,8 +98,8 @@ func TestWebhookHandler(t *testing.T) {
 		expectCode int
 	}{
 		{"sha1=d1e100e3f17e8399b73137382896ff1536c59457", "goci-invalid", http.StatusBadRequest},
-		{"sha1=d1e100e3f17e8399b73137382896ff1536c59457", "push", http.StatusOK},
-		{"sha1=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "push", http.StatusBadRequest},
+		{"sha1=d1e100e3f17e8399b73137382896ff1536c59457", "issues", http.StatusOK},
+		{"sha1=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "issues", http.StatusBadRequest},
 	}
 
 	for _, test := range tests {
@@ -165,7 +174,87 @@ func TestIntegrationInstallationEvent(t *testing.T) {
 	memDB.ForceError(nil)
 }
 
-func TestPullRequestEvent(t *testing.T) {
+func TestPushConfig(t *testing.T) {
+	want := analyseConfig{
+		eventType:      analyser.EventTypePush,
+		installationID: 1,
+		statusesURL:    "https://github.com/owner/repo/status/abcdef",
+		baseURL:        "https://github.com/owner/repo.git",
+		baseRef:        "abcdef~2",
+		headURL:        "https://github.com/owner/repo.git",
+		headRef:        "abcdef",
+		goSrcPath:      "github.com/owner/repo",
+	}
+	e := &github.PushEvent{
+		Installation: &github.Installation{
+			ID: github.Int(1),
+		},
+		Repo: &github.PushEventRepository{
+			StatusesURL: github.String("https://github.com/owner/repo/status/{sha}"),
+			CloneURL:    github.String("https://github.com/owner/repo.git"),
+			HTMLURL:     github.String("https://github.com/owner/repo"),
+		},
+		After:   github.String("abcdef"),
+		Commits: []github.PushEventCommit{{}, {}},
+	}
+
+	have := PushConfig(e)
+	if have != want {
+		t.Errorf("have:\n%+v\nwant:\n%+v", have, want)
+	}
+
+}
+
+func TestPullRequestConfig(t *testing.T) {
+	want := analyseConfig{
+		eventType:      analyser.EventTypePullRequest,
+		installationID: 1,
+		statusesURL:    "https://github.com/owner/repo/status/abcdef",
+		baseURL:        "https://github.com/owner/repo.git",
+		baseRef:        "base-branch",
+		headURL:        "https://github.com/owner/repo.git",
+		headRef:        "head-branch",
+		goSrcPath:      "github.com/owner/repo",
+		owner:          "owner",
+		repo:           "repo",
+		pr:             2,
+		sha:            "abcdef",
+	}
+	e := &github.PullRequestEvent{
+		Action: github.String("opened"),
+		Number: github.Int(2),
+		PullRequest: &github.PullRequest{
+			StatusesURL: github.String("https://github.com/owner/repo/status/abcdef"),
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					HTMLURL:  github.String("https://github.com/owner/repo"),
+					CloneURL: github.String("https://github.com/owner/repo.git"),
+					Name:     github.String("repo"),
+					Owner: &github.User{
+						Login: github.String("owner"),
+					},
+				},
+				Ref: github.String("base-branch"),
+			},
+			Head: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					CloneURL: github.String("https://github.com/owner/repo.git"),
+				},
+				SHA: github.String("abcdef"),
+				Ref: github.String("head-branch"),
+			},
+		},
+		Installation: &github.Installation{
+			ID: github.Int(1),
+		},
+	}
+	have := PullRequestConfig(e)
+	if have != want {
+		t.Errorf("have:\n%+v\nwant:\n%+v", have, want)
+	}
+}
+
+func TestAnalyse(t *testing.T) {
 	g, mockAnalyser, memDB := setup(t)
 
 	var (
@@ -175,12 +264,6 @@ func TestPullRequestEvent(t *testing.T) {
 	)
 
 	var (
-		expectedConfig = analyser.Config{
-			BaseURL:    "base-repo-url",
-			BaseBranch: "base-branch",
-			HeadURL:    "head-repo-url",
-			HeadBranch: "head-branch",
-		}
 		expectedCmtBody   = "Name: error"
 		expectedCmtPath   = "main.go"
 		expectedCmtPos    = 1
@@ -188,20 +271,12 @@ func TestPullRequestEvent(t *testing.T) {
 		expectedOwner     = "owner"
 		expectedRepo      = "repo"
 		expectedPR        = 3
-		expectedGoSrcPath = "gitub.com/owner/repo"
+		expectedGoSrcPath = "github.com/owner/repo"
 	)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		decoder := json.NewDecoder(r.Body)
 		switch r.RequestURI {
-		case "/diff-url":
-			fmt.Fprintln(w, `diff --git a/subdir/main.go b/subdir/main.go
-new file mode 100644
-index 0000000..6362395
---- /dev/null
-+++ b/main.go
-@@ -0,0 +1,1 @@
-+var _ = fmt.Sprintln()`)
 		case "/status-url":
 			// Make sure status was set to pending and then success
 			var status struct {
@@ -245,7 +320,6 @@ index 0000000..6362395
 	}))
 	defer ts.Close()
 	g.baseURL = ts.URL
-	expectedConfig.DiffURL = ts.URL + "/diff-url"
 
 	const (
 		installationID = 2
@@ -260,41 +334,22 @@ index 0000000..6362395
 		{Name: "Name", Path: "tool", Args: "-flag %BASE_BRANCH% ./..."},
 	}
 
-	event := &github.PullRequestEvent{
-		Action: github.String("opened"),
-		Number: github.Int(expectedPR),
-		PullRequest: &github.PullRequest{
-			HTMLURL:     github.String("https://github.com.au/owner/repo/pulls/3"),
-			StatusesURL: github.String(ts.URL + "/status-url"),
-			DiffURL:     github.String(expectedConfig.DiffURL),
-			Base: &github.PullRequestBranch{
-				Repo: &github.Repository{
-					HTMLURL:  github.String("https://" + expectedGoSrcPath),
-					CloneURL: github.String(expectedConfig.BaseURL),
-					Name:     github.String(expectedRepo),
-					Owner: &github.User{
-						Login: github.String(expectedOwner),
-					},
-				},
-				Ref: github.String(expectedConfig.BaseBranch),
-			},
-			Head: &github.PullRequestBranch{
-				Repo: &github.Repository{
-					CloneURL: github.String(expectedConfig.HeadURL),
-				},
-				SHA: github.String(expectedCmtSHA),
-				Ref: github.String(expectedConfig.HeadBranch),
-			},
-		},
-		Repo: &github.Repository{
-			URL: github.String("repo-url"),
-		},
-		Installation: &github.Installation{
-			ID: github.Int(installationID),
-		},
+	cfg := analyseConfig{
+		eventType:      analyser.EventTypePullRequest,
+		installationID: installationID,
+		statusesURL:    ts.URL + "/status-url",
+		baseURL:        "https://github.com/owner/repo.git",
+		baseRef:        "base-branch",
+		headURL:        "https://github.com/owner/repo.git",
+		headRef:        "head-branch",
+		goSrcPath:      "github.com/owner/repo",
+		owner:          expectedOwner,
+		repo:           expectedRepo,
+		pr:             expectedPR,
+		sha:            expectedCmtSHA,
 	}
 
-	err := g.PullRequestEvent(event)
+	err := g.Analyse(cfg)
 	switch {
 	case err != nil:
 		t.Errorf("did not expect error: %v", err)
@@ -313,24 +368,15 @@ func TestPullRequestEvent_noInstall(t *testing.T) {
 	g, _, _ := setup(t)
 
 	const installationID = 2
-	event := &github.PullRequestEvent{
-		Action: github.String("opened"),
-		PullRequest: &github.PullRequest{
-			HTMLURL: github.String("https://github.com.au/owner/repo/pulls/3"),
-		},
-		Number: github.Int(1),
-		Installation: &github.Installation{
-			ID: github.Int(installationID),
-		},
-	}
+	cfg := analyseConfig{installationID: installationID}
 
-	err := g.PullRequestEvent(event)
+	err := g.Analyse(cfg)
 	if want := errors.New("could not find installation with ID 2"); err.Error() != want.Error() {
 		t.Errorf("expected error %q have %q", want, err)
 	}
 }
 
-func TestPullRequestEvent_disabled(t *testing.T) {
+func TestAnalyse_disabled(t *testing.T) {
 	g, _, memDB := setup(t)
 
 	const installationID = 2
@@ -338,18 +384,9 @@ func TestPullRequestEvent_disabled(t *testing.T) {
 	// Added but not enabled
 	_ = memDB.AddGHInstallation(installationID, 3, 4)
 
-	event := &github.PullRequestEvent{
-		Action: github.String("opened"),
-		PullRequest: &github.PullRequest{
-			HTMLURL: github.String("https://github.com.au/owner/repo/pulls/3"),
-		},
-		Number: github.Int(1),
-		Installation: &github.Installation{
-			ID: github.Int(installationID),
-		},
-	}
+	cfg := analyseConfig{installationID: installationID}
 
-	err := g.PullRequestEvent(event)
+	err := g.Analyse(cfg)
 	if want := errors.New("could not find installation with ID 2"); err.Error() != want.Error() {
 		t.Errorf("expected error %q have %q", want, err)
 	}

--- a/internal/queue/gcp-pubsub.go
+++ b/internal/queue/gcp-pubsub.go
@@ -21,6 +21,7 @@ import (
 func init() {
 	// List of all types that could be added to the queue
 	gob.Register(&github.PullRequestEvent{})
+	gob.Register(&github.PushEvent{})
 }
 
 const (

--- a/main.go
+++ b/main.go
@@ -177,8 +177,16 @@ func queueListen(ctx context.Context, queueChan <-chan interface{}, g *github.Gi
 			log.Printf("queueListen: reading job type %T", job)
 			var err error
 			switch e := job.(type) {
+			case *gh.PushEvent:
+				err = g.Analyse(github.PushConfig(e))
+				if err != nil {
+					err = errors.Wrapf(err, "cannot analyse push event for sha %v on repo %v", *e.After, *e.Repo.HTMLURL)
+				}
 			case *gh.PullRequestEvent:
-				err = g.PullRequestEvent(e)
+				err = g.Analyse(github.PullRequestConfig(e))
+				if err != nil {
+					err = errors.Wrapf(err, "cannot analyse pr %v", e.PullRequest.HTMLURL)
+				}
 			default:
 				err = fmt.Errorf("unknown queue job type %T", e)
 			}


### PR DESCRIPTION
This is accomplished with a few refactors.

We no longer fetch the diff URL provided in a Pull Request event,
it was convenient, but it's not available in Pushes and we can
easily calculate it ourselves without the need for the extra
lookup. This was GitHub specific too, other providers may not have
provided that URL.

Analyse does need to process a Push differently than a Pull Request,
and this is managed by the EventType type.

We ignore the GitHub push event's Before SHA ref, during testing
force pushes, this would be the ref of the commit that's being
"overwritten" so it wouldn't exist when clonsed. Unlike a
non-forced push, where the commit exists after the clone. So instead
of using Before, we use After~len(Commits), so no matter how many
commits are being pushed, or whether the previous commit exists or
not, we should be able to process it.

Resolves #27.