### PR TITLE
Support GitHub PushEvent

### DIFF
--- a/internal/analyser/analyser_test.go
+++ b/internal/analyser/analyser_test.go
@@ -2,8 +2,6 @@ package analyser
 
 import (
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -35,26 +33,13 @@ func (a *mockAnalyser) Stop() error {
 	return nil
 }
 
-func TestAnalyse(t *testing.T) {
-	var diffFetched bool
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		diffFetched = true
-		fmt.Fprintln(w, `diff --git a/subdir/main.go b/subdir/main.go
-new file mode 100644
-index 0000000..6362395
---- /dev/null
-+++ b/main.go
-@@ -0,0 +1,1 @@
-+var _ = fmt.Sprintln()`)
-	}))
-	defer ts.Close()
-
+func TestAnalyse_pr(t *testing.T) {
 	cfg := Config{
-		BaseURL:    "base-url",
-		BaseBranch: "base-branch",
-		HeadURL:    "head-url",
-		HeadBranch: "head-branch",
-		DiffURL:    ts.URL,
+		EventType: EventTypePullRequest,
+		BaseURL:   "base-url",
+		BaseRef:   "base-branch",
+		HeadURL:   "head-url",
+		HeadRef:   "head-branch",
 	}
 
 	tools := []db.Tool{
@@ -62,11 +47,20 @@ index 0000000..6362395
 		{Name: "Name2", Path: "tool2"},
 	}
 
+	diff := []byte(`diff --git a/subdir/main.go b/subdir/main.go
+new file mode 100644
+index 0000000..6362395
+--- /dev/null
++++ b/main.go
+@@ -0,0 +1,1 @@
++var _ = fmt.Sprintln()`)
+
 	analyser := &mockAnalyser{
 		ExecuteOut: [][]byte{
-			{}, // git clone
-			{}, // git fetch
-			{}, // install-deps.sh
+			{},   // git clone
+			{},   // git fetch
+			diff, // git diff
+			{},   // install-deps.sh
 			[]byte(`/go/src/gopherci`),                   // pwd
 			[]byte("main.go:1: error1"),                  // tool 1
 			[]byte("/go/src/gopherci/main.go:1: error2"), // tool 2 output abs paths
@@ -86,17 +80,14 @@ index 0000000..6362395
 		t.Errorf("expected issues:\n%+v\ngot:\n%+v", expected, issues)
 	}
 
-	if !diffFetched {
-		t.Errorf("expected diff to be fetched")
-	}
-
 	if !analyser.Stopped {
 		t.Errorf("expected analyser to be stopped")
 	}
 
 	expectedArgs := [][]string{
-		{"git", "clone", "--branch", "head-branch", "--depth", "1", "--single-branch", "head-url", "."},
-		{"git", "fetch", cfg.BaseURL, cfg.BaseBranch},
+		{"git", "clone", "--depth", "1", "--branch", cfg.HeadRef, "--single-branch", cfg.HeadURL, "."},
+		{"git", "fetch", "--depth", "1", cfg.BaseURL, cfg.BaseRef},
+		{"git", "diff", fmt.Sprintf("FETCH_HEAD...%v", cfg.HeadRef)},
 		{"install-deps.sh"},
 		{"pwd"},
 		{"tool1", "-flag", "FETCH_HEAD", "./..."},
@@ -105,5 +96,80 @@ index 0000000..6362395
 
 	if !reflect.DeepEqual(analyser.Executed, expectedArgs) {
 		t.Errorf("\nhave %v\nwant %v", analyser.Executed, expectedArgs)
+	}
+}
+
+func TestAnalyse_push(t *testing.T) {
+	cfg := Config{
+		EventType: EventTypePush,
+		BaseURL:   "base-url",
+		BaseRef:   "abcde~1",
+		HeadURL:   "head-url",
+		HeadRef:   "abcde",
+	}
+
+	tools := []db.Tool{
+		{Name: "Name1", Path: "tool1", Args: "-flag %BASE_BRANCH% ./..."},
+		{Name: "Name2", Path: "tool2"},
+	}
+
+	diff := []byte(`diff --git a/subdir/main.go b/subdir/main.go
+new file mode 100644
+index 0000000..6362395
+--- /dev/null
++++ b/main.go
+@@ -0,0 +1,1 @@
++var _ = fmt.Sprintln()`)
+
+	analyser := &mockAnalyser{
+		ExecuteOut: [][]byte{
+			{},   // git clone
+			{},   // git checkout
+			diff, // git diff
+			{},   // install-deps.sh
+			[]byte(`/go/src/gopherci`),                   // pwd
+			[]byte("main.go:1: error1"),                  // tool 1
+			[]byte("/go/src/gopherci/main.go:1: error2"), // tool 2 output abs paths
+		},
+	}
+
+	issues, err := Analyse(analyser, tools, cfg)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	expected := []Issue{
+		{File: "main.go", HunkPos: 1, Issue: "Name1: error1"},
+		{File: "main.go", HunkPos: 1, Issue: "Name2: error2"},
+	}
+	if !reflect.DeepEqual(expected, issues) {
+		t.Errorf("expected issues:\n%+v\ngot:\n%+v", expected, issues)
+	}
+
+	if !analyser.Stopped {
+		t.Errorf("expected analyser to be stopped")
+	}
+
+	expectedArgs := [][]string{
+		{"git", "clone", cfg.HeadURL, "."},
+		{"git", "checkout", cfg.HeadRef},
+		{"git", "diff", fmt.Sprintf("%v...%v", cfg.BaseRef, cfg.HeadRef)},
+		{"install-deps.sh"},
+		{"pwd"},
+		{"tool1", "-flag", "abcde~1", "./..."},
+		{"tool2"},
+	}
+
+	if !reflect.DeepEqual(analyser.Executed, expectedArgs) {
+		t.Errorf("\nhave %v\nwant %v", analyser.Executed, expectedArgs)
+	}
+}
+
+func TestAnalyse_unknown(t *testing.T) {
+	cfg := Config{}
+	analyser := &mockAnalyser{}
+	_, err := Analyse(analyser, nil, cfg)
+	if err == nil {
+		t.Fatal("expected error got nil")
 	}
 }

--- a/internal/queue/gcp-pubsub.go
+++ b/internal/queue/gcp-pubsub.go
@@ -21,6 +21,7 @@ import (
 func init() {
 	// List of all types that could be added to the queue
 	gob.Register(&github.PullRequestEvent{})
+	gob.Register(&github.PushEvent{})
 }
 
 const (

--- a/main.go
+++ b/main.go
@@ -177,8 +177,16 @@ func queueListen(ctx context.Context, queueChan <-chan interface{}, g *github.Gi
 			log.Printf("queueListen: reading job type %T", job)
 			var err error
 			switch e := job.(type) {
+			case *gh.PushEvent:
+				err = g.Analyse(github.PushConfig(e))
+				if err != nil {
+					err = errors.Wrapf(err, "cannot analyse push event for sha %v on repo %v", *e.After, *e.Repo.HTMLURL)
+				}
 			case *gh.PullRequestEvent:
-				err = g.PullRequestEvent(e)
+				err = g.Analyse(github.PullRequestConfig(e))
+				if err != nil {
+					err = errors.Wrapf(err, "cannot analyse pr %v", e.PullRequest.HTMLURL)
+				}
 			default:
 				err = fmt.Errorf("unknown queue job type %T", e)
 			}


### PR DESCRIPTION
This is accomplished with a few refactors.

We no longer fetch the diff URL provided in a Pull Request event,
it was convenient, but it's not available in Pushes and we can
easily calculate it ourselves without the need for the extra
lookup. This was GitHub specific too, other providers may not have
provided that URL.

Analyse does need to process a Push differently than a Pull Request,
and this is managed by the EventType type.

We ignore the GitHub push event's Before SHA ref, during testing
force pushes, this would be the ref of the commit that's being
"overwritten" so it wouldn't exist when clonsed. Unlike a
non-forced push, where the commit exists after the clone. So instead
of using Before, we use After~len(Commits), so no matter how many
commits are being pushed, or whether the previous commit exists or
not, we should be able to process it.

Resolves #27.