### PR TITLE
Add /pr or /push suffix to GitHub Status API context

### DIFF
--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -176,14 +176,15 @@ func TestIntegrationInstallationEvent(t *testing.T) {
 
 func TestPushConfig(t *testing.T) {
 	want := AnalyseConfig{
-		eventType:      analyser.EventTypePush,
-		installationID: 1,
-		statusesURL:    "https://github.com/owner/repo/status/abcdef",
-		baseURL:        "https://github.com/owner/repo.git",
-		baseRef:        "abcdef~2",
-		headURL:        "https://github.com/owner/repo.git",
-		headRef:        "abcdef",
-		goSrcPath:      "github.com/owner/repo",
+		eventType:       analyser.EventTypePush,
+		installationID:  1,
+		statusesContext: "ci/gopherci/push",
+		statusesURL:     "https://github.com/owner/repo/status/abcdef",
+		baseURL:         "https://github.com/owner/repo.git",
+		baseRef:         "abcdef~2",
+		headURL:         "https://github.com/owner/repo.git",
+		headRef:         "abcdef",
+		goSrcPath:       "github.com/owner/repo",
 	}
 	e := &github.PushEvent{
 		Installation: &github.Installation{
@@ -207,18 +208,19 @@ func TestPushConfig(t *testing.T) {
 
 func TestPullRequestConfig(t *testing.T) {
 	want := AnalyseConfig{
-		eventType:      analyser.EventTypePullRequest,
-		installationID: 1,
-		statusesURL:    "https://github.com/owner/repo/status/abcdef",
-		baseURL:        "https://github.com/owner/repo.git",
-		baseRef:        "base-branch",
-		headURL:        "https://github.com/owner/repo.git",
-		headRef:        "head-branch",
-		goSrcPath:      "github.com/owner/repo",
-		owner:          "owner",
-		repo:           "repo",
-		pr:             2,
-		sha:            "abcdef",
+		eventType:       analyser.EventTypePullRequest,
+		installationID:  1,
+		statusesContext: "ci/gopherci/pr",
+		statusesURL:     "https://github.com/owner/repo/status/abcdef",
+		baseURL:         "https://github.com/owner/repo.git",
+		baseRef:         "base-branch",
+		headURL:         "https://github.com/owner/repo.git",
+		headRef:         "head-branch",
+		goSrcPath:       "github.com/owner/repo",
+		owner:           "owner",
+		repo:            "repo",
+		pr:              2,
+		sha:             "abcdef",
 	}
 	e := &github.PullRequestEvent{
 		Action: github.String("opened"),
@@ -335,18 +337,19 @@ func TestAnalyse(t *testing.T) {
 	}
 
 	cfg := AnalyseConfig{
-		eventType:      analyser.EventTypePullRequest,
-		installationID: installationID,
-		statusesURL:    ts.URL + "/status-url",
-		baseURL:        "https://github.com/owner/repo.git",
-		baseRef:        "base-branch",
-		headURL:        "https://github.com/owner/repo.git",
-		headRef:        "head-branch",
-		goSrcPath:      "github.com/owner/repo",
-		owner:          expectedOwner,
-		repo:           expectedRepo,
-		pr:             expectedPR,
-		sha:            expectedCmtSHA,
+		eventType:       analyser.EventTypePullRequest,
+		installationID:  installationID,
+		statusesContext: "ci/gopherci/pr",
+		statusesURL:     ts.URL + "/status-url",
+		baseURL:         "https://github.com/owner/repo.git",
+		baseRef:         "base-branch",
+		headURL:         "https://github.com/owner/repo.git",
+		headRef:         "head-branch",
+		goSrcPath:       "github.com/owner/repo",
+		owner:           expectedOwner,
+		repo:            expectedRepo,
+		pr:              expectedPR,
+		sha:             expectedCmtSHA,
 	}
 
 	err := g.Analyse(cfg)

--- a/internal/github/installation.go
+++ b/internal/github/installation.go
@@ -59,14 +59,14 @@ const (
 )
 
 // SetStatus sets the CI Status API
-func (i *Installation) SetStatus(statusURL string, status StatusState, description string) error {
+func (i *Installation) SetStatus(context, statusURL string, status StatusState, description string) error {
 	s := struct {
 		State       string `json:"state,omitempty"`
 		TargetURL   string `json:"target_url,omitempty"`
 		Description string `json:"description,omitempty"`
 		Context     string `json:"context,omitempty"`
 	}{
-		string(status), "", description, "ci/gopherci",
+		string(status), "", description, context,
 	}
 	log.Printf("status: %#v", status)
 


### PR DESCRIPTION
When viewing a GitHub pull request, either via API or through github.com,
the status API will show the status based on either the pull request or
the last commit if either have a status (eg success/failed).

If both have a status, and both use the same context "ci/gopherci",
the statuses would overwrite each other. For example, if the pull
request status API returned "success: Found 2 issues", but the user
pushed another commit, the push could set the status to "success:
Found 1 issue". This would overwrite the pull request's status which
tracks the entire pull request.

This change follows Travis CI's naming convention, although they may
be doing this for other requests, by adding a "/pr" or "/push" suffix,
such as "ci/gopherci/pr" and "ci/gopherci/push".