### PR TITLE
Don't post duplicate comments on a PR

### DIFF
--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -183,9 +183,14 @@ func (g *GitHub) Analyse(cfg AnalyseConfig) error {
 	// pushes, there are no comments, so suppressed is 0.
 	var suppressed = 0
 	if cfg.pr != 0 {
-		suppressed, err = install.WriteIssues(ctx, cfg.owner, cfg.repo, cfg.pr, cfg.sha, issues)
+		suppressed, issues, err = install.FilterIssues(ctx, cfg.owner, cfg.repo, cfg.pr, issues)
 		if err != nil {
-			return errors.Wrap(err, "could not write comment")
+			return err
+		}
+
+		err = install.WriteIssues(ctx, cfg.owner, cfg.repo, cfg.pr, cfg.sha, issues)
+		if err != nil {
+			return err
 		}
 		log.Printf("wrote %v issues as comments, suppressed %v", len(issues)-suppressed, suppressed)
 	}

--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -300,6 +300,11 @@ func TestAnalyse(t *testing.T) {
 			// respond with any token to installation transport
 			fmt.Fprintln(w, "{}")
 		case fmt.Sprintf("/repos/%v/%v/pulls/%v/comments", expectedOwner, expectedRepo, expectedPR):
+			if r.Method == "GET" {
+				// list comments - respond with empty array
+				fmt.Fprintln(w, "[]")
+				break
+			}
 			expected := github.PullRequestComment{
 				Body:     github.String(expectedCmtBody),
 				Path:     github.String(expectedCmtPath),

--- a/internal/github/installation_test.go
+++ b/internal/github/installation_test.go
@@ -14,6 +14,76 @@ import (
 	"github.com/google/go-github/github"
 )
 
+func TestFilterIssues_maxIssueComments(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	i := Installation{client: github.NewClient(nil)}
+	i.client.BaseURL, _ = url.Parse(ts.URL)
+
+	// Number of issues to suppress
+	suppress := 1
+
+	// Add more issues than maxIssueComments
+	var issues []analyser.Issue
+	for n := 0; n < maxIssueComments+suppress; n++ {
+		issues = append(issues, analyser.Issue{File: "file.go", HunkPos: n, Issue: "body"})
+	}
+
+	suppressed, filtered, err := i.FilterIssues(context.Background(), "owner", "repo", 2, issues)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Ensure we don't send more comments than maxIssueComments
+	if len(filtered) > maxIssueComments {
+		t.Errorf("filtered comment count %v is greater than maxIssueComments %v", len(filtered), maxIssueComments)
+	}
+
+	if suppressed != suppress {
+		t.Errorf("suppressed have %v want %v", suppressed, suppress)
+	}
+}
+
+func TestFilterIssues_deduplicate(t *testing.T) {
+	var (
+		expectedOwner   = "owner"
+		expectedRepo    = "repo"
+		expectedPR      = 2
+		expectedCmtBody = "body"
+		expectedCmtPath = "path.go"
+		expectedCmtPos  = 4
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case fmt.Sprintf("/repos/%v/%v/pulls/%v/comments", expectedOwner, expectedRepo, expectedPR):
+			comments := []*github.PullRequestComment{{
+				Body:     github.String(expectedCmtBody),
+				Path:     github.String(expectedCmtPath),
+				Position: github.Int(expectedCmtPos),
+			}}
+			json, _ := json.Marshal(comments)
+			fmt.Fprint(w, string(json))
+		}
+	}))
+	defer ts.Close()
+
+	i := Installation{client: github.NewClient(nil)}
+	i.client.BaseURL, _ = url.Parse(ts.URL)
+
+	var issues = []analyser.Issue{{File: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody}}
+
+	_, filtered, err := i.FilterIssues(context.Background(), expectedOwner, expectedRepo, expectedPR, issues)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if want := 0; len(filtered) != want {
+		t.Errorf("filtered comment count %v does not match %v", len(filtered), want)
+	}
+}
+
 func TestWriteIssues(t *testing.T) {
 	var (
 		expectedOwner   = "owner"
@@ -23,7 +93,6 @@ func TestWriteIssues(t *testing.T) {
 		expectedCmtPath = "path"
 		expectedCmtPos  = 4
 		expectedCmtSHA  = "abc123"
-		commentCount    = 0
 	)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -43,8 +112,6 @@ func TestWriteIssues(t *testing.T) {
 			}
 			if !reflect.DeepEqual(expected, comment) {
 				t.Fatalf("expected cmt:\n%#v\ngot:\n%#v", expected, comment)
-			} else {
-				commentCount++
 			}
 		default:
 			t.Logf(r.RequestURI)
@@ -55,26 +122,10 @@ func TestWriteIssues(t *testing.T) {
 	i := Installation{client: github.NewClient(nil)}
 	i.client.BaseURL, _ = url.Parse(ts.URL)
 
-	// Number of issues to suppress
-	suppress := 1
+	var issues = []analyser.Issue{{File: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody}}
 
-	// Add more issues than maxIssueComments
-	var issues []analyser.Issue
-	for n := 0; n < maxIssueComments+suppress; n++ {
-		issues = append(issues, analyser.Issue{File: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody})
-	}
-
-	suppressed, err := i.WriteIssues(context.Background(), expectedOwner, expectedRepo, expectedPR, expectedCmtSHA, issues)
+	err := i.WriteIssues(context.Background(), expectedOwner, expectedRepo, expectedPR, expectedCmtSHA, issues)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Ensure we don't send more comments than maxIssueComments
-	if commentCount != maxIssueComments {
-		t.Errorf("commentCount %v does not match maxIssueComments %v", commentCount, maxIssueComments)
-	}
-
-	if suppressed != suppress {
-		t.Errorf("suppressed have %v want %v", suppressed, suppress)
 	}
 }

--- a/testdata/dupe-issue-comments.sh
+++ b/testdata/dupe-issue-comments.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -eux
+
+cat > foo2.go <<EOF
+package foo
+func Foo2() {} // expect golint exported without comment
+EOF
+
+git add .
+git commit -m "2nd"
+
+git push -f


### PR DESCRIPTION
Before writing comments on an issue, this change filters
those issues to only issues that have not been posted already.

Additionally, the WriteIssues function was refactored slightly
to only post comments, previously it was only writing a maximum
amount before returning the number of comments suppressed. This
max comments functionality has been added to the new FilterIssues
method.

The integration tests have also been expanded to include
a test, although, this wasn't strictly necessary. The integration
tests have also been updated to support the GitHub API's new
context arguments.

Resolves #62.