### PR TITLE
Ignore issues in generated code, or vendored/testdata directories

### DIFF
--- a/internal/analyser/analyser_test.go
+++ b/internal/analyser/analyser_test.go
@@ -11,6 +11,7 @@ import (
 type mockAnalyser struct {
 	Executed   [][]string
 	ExecuteOut [][]byte
+	ExecuteErr []error
 	Stopped    bool
 }
 
@@ -25,6 +26,7 @@ func (a *mockAnalyser) NewExecuter(_ string) (Executer, error) {
 func (a *mockAnalyser) Execute(args []string) (out []byte, err error) {
 	a.Executed = append(a.Executed, args)
 	out, a.ExecuteOut = a.ExecuteOut[0], a.ExecuteOut[1:]
+	err, a.ExecuteErr = a.ExecuteErr[0], a.ExecuteErr[1:]
 	return out, err
 }
 
@@ -45,6 +47,7 @@ func TestAnalyse_pr(t *testing.T) {
 	tools := []db.Tool{
 		{Name: "Name1", Path: "tool1", Args: "-flag %BASE_BRANCH% ./..."},
 		{Name: "Name2", Path: "tool2"},
+		{Name: "Name2", Path: "tool3"},
 	}
 
 	diff := []byte(`diff --git a/subdir/main.go b/subdir/main.go
@@ -63,7 +66,24 @@ index 0000000..6362395
 			{},   // install-deps.sh
 			[]byte(`/go/src/gopherci`),                   // pwd
 			[]byte("main.go:1: error1"),                  // tool 1
+			[]byte("file is not generated"),              // isFileGenerated
 			[]byte("/go/src/gopherci/main.go:1: error2"), // tool 2 output abs paths
+			[]byte("file is not generated"),              // isFileGenerated
+			[]byte("main.go:1: error3"),                  // tool 3 tested a generated file
+			[]byte("file is generated"),                  // isFileGenerated
+		},
+		ExecuteErr: []error{
+			nil, // git clone
+			nil, // git fetch
+			nil, // git diff
+			nil, // install-deps.sh
+			nil, // pwd
+			nil, // tool 1
+			&NonZeroError{ExitCode: 1}, // isFileGenerated - not generated
+			nil, // tool 2 output abs paths
+			&NonZeroError{ExitCode: 1}, // isFileGenerated - not generated
+			nil, // tool 3 tested a generated file
+			nil, // isFileGenerated - generated
 		},
 	}
 
@@ -91,7 +111,11 @@ index 0000000..6362395
 		{"install-deps.sh"},
 		{"pwd"},
 		{"tool1", "-flag", "FETCH_HEAD", "./..."},
+		{"isFileGenerated", "/go/src/gopherci", "main.go"},
 		{"tool2"},
+		{"isFileGenerated", "/go/src/gopherci", "main.go"},
+		{"tool3"},
+		{"isFileGenerated", "/go/src/gopherci", "main.go"},
 	}
 
 	if !reflect.DeepEqual(analyser.Executed, expectedArgs) {
@@ -111,6 +135,7 @@ func TestAnalyse_push(t *testing.T) {
 	tools := []db.Tool{
 		{Name: "Name1", Path: "tool1", Args: "-flag %BASE_BRANCH% ./..."},
 		{Name: "Name2", Path: "tool2"},
+		{Name: "Name2", Path: "tool3"},
 	}
 
 	diff := []byte(`diff --git a/subdir/main.go b/subdir/main.go
@@ -129,7 +154,24 @@ index 0000000..6362395
 			{},   // install-deps.sh
 			[]byte(`/go/src/gopherci`),                   // pwd
 			[]byte("main.go:1: error1"),                  // tool 1
+			[]byte("file is not generated"),              // isFileGenerated
 			[]byte("/go/src/gopherci/main.go:1: error2"), // tool 2 output abs paths
+			[]byte("file is not generated"),              // isFileGenerated
+			[]byte("main.go:1: error3"),                  // tool 3 tested a generated file
+			[]byte("file is generated"),                  // isFileGenerated
+		},
+		ExecuteErr: []error{
+			nil, // git clone
+			nil, // git checkout
+			nil, // git diff
+			nil, // install-deps.sh
+			nil, // pwd
+			nil, // tool 1
+			&NonZeroError{ExitCode: 1}, // isFileGenerated - not generated
+			nil, // tool 2 output abs paths
+			&NonZeroError{ExitCode: 1}, // isFileGenerated - not generated
+			nil, // tool 3 tested a generated file
+			nil, // isFileGenerated - generated
 		},
 	}
 
@@ -157,7 +199,11 @@ index 0000000..6362395
 		{"install-deps.sh"},
 		{"pwd"},
 		{"tool1", "-flag", "abcde~1", "./..."},
+		{"isFileGenerated", "/go/src/gopherci", "main.go"},
 		{"tool2"},
+		{"isFileGenerated", "/go/src/gopherci", "main.go"},
+		{"tool3"},
+		{"isFileGenerated", "/go/src/gopherci", "main.go"},
 	}
 
 	if !reflect.DeepEqual(analyser.Executed, expectedArgs) {

--- a/internal/analyser/docker.go
+++ b/internal/analyser/docker.go
@@ -139,7 +139,7 @@ func (e *DockerExecuter) Execute(args []string) ([]byte, error) {
 		return nil, errors.Wrap(err, fmt.Sprintf("could not inspect exec for containerID %v", e.container.ID))
 	}
 	if inspect.ExitCode != 0 {
-		return buf.Bytes(), fmt.Errorf("exit code: %v, config: %+v", inspect.ExitCode, inspect.ProcessConfig)
+		return buf.Bytes(), &NonZeroError{ExitCode: inspect.ExitCode, args: args}
 	}
 
 	return buf.Bytes(), nil

--- a/internal/analyser/docker_test.go
+++ b/internal/analyser/docker_test.go
@@ -2,6 +2,7 @@ package analyser
 
 import (
 	"log"
+	"strings"
 	"testing"
 )
 
@@ -33,9 +34,9 @@ func TestDocker(t *testing.T) {
 		t.Errorf("\nwant: %q\nhave: %q", want, out)
 	}
 
-	wantPrefix := "exit code: 1"
-	if err.Error()[:len(wantPrefix)] != wantPrefix {
-		t.Errorf("\nwantPrefix: %q\nhave: %q", wantPrefix, err)
+	wantSuffix := "exit code 1"
+	if !strings.HasSuffix(err.Error(), wantSuffix) {
+		t.Errorf("\nwantSuffix: %q\nhave: %q", wantSuffix, err)
 	}
 
 	err = exec.Stop()

--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -68,6 +68,9 @@ index 0000000..6362395
 	if len(args) > 0 && args[0] == "tool" {
 		return []byte(`main.go:1: error`), nil
 	}
+	if len(args) > 0 && args[0] == "isFileGenerated" {
+		return nil, &analyser.NonZeroError{ExitCode: 1}
+	}
 	return nil, nil
 }
 func (a *mockAnalyser) Stop() error { return nil }

--- a/testdata/issue-comments-ignore-generated.sh
+++ b/testdata/issue-comments-ignore-generated.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eux
+
+git checkout -b issue-comments-ignore-generated
+
+cat > generated.go <<EOF
+// automatically generated - DO NOT EDIT
+package foo
+func Foo() {}  // expect golint exported without comment
+EOF
+
+mkdir testdata
+cat > testdata/foo.go <<EOF
+package foo
+func Foo() {}  // expect golint exported without comment
+EOF
+
+mkdir vendor
+cat > vendor/foo.go <<EOF
+package foo
+func Foo() {}  // expect golint exported without comment
+EOF
+
+git add .
+git commit -m "commit"
+
+git push -f -u origin HEAD


### PR DESCRIPTION
We consider generated code, anything that appears to be generated
or is in a vendor/testdata directory. GopherCI uses
github.com/gopherci/isFileGenerated which mostly uses a function
provided by github.com/shurcooL/go.

In using isFileGenerated, it makes it difficult for a user to provide
additional files to be ignored, this would need to be implemented in
similar areas by other method if we decide to support that option.

This causes all issues from generated code to be ignored, there
will be no option to only comment, or only set the build to failed
as the issue will be ignored as soon as it's detected.

An additional integration test has been provided, because although
there are unit tests, it's possible the underlying tools misbehave
or change their implementation details.

Resolves #57.
