### PR TITLE
GCPPubSub refactor to support new streaming client API

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -6,14 +6,13 @@ import (
 	"github.com/bradleyfalzon/ghinstallation"
 	"github.com/bradleyfalzon/gopherci/internal/analyser"
 	"github.com/bradleyfalzon/gopherci/internal/db"
-	"github.com/bradleyfalzon/gopherci/internal/queue"
 )
 
 // GitHub is the type gopherci uses to interract with github.com.
 type GitHub struct {
 	db             db.DB
 	analyser       analyser.Analyser
-	queuer         queue.Queuer
+	queuePush      chan<- interface{}
 	webhookSecret  []byte            // shared webhook secret configured for the integration
 	integrationID  int               // id is the integration id
 	integrationKey []byte            // integrationKey is the private key for the installationID
@@ -26,11 +25,11 @@ type GitHub struct {
 // integrationID is the GitHub Integration ID (not installation ID).
 // integrationKey is the key for the integrationID provided to you by GitHub
 // during the integration registration.
-func New(analyser analyser.Analyser, db db.DB, queuer queue.Queuer, integrationID int, integrationKey []byte, webhookSecret string) (*GitHub, error) {
+func New(analyser analyser.Analyser, db db.DB, queuePush chan<- interface{}, integrationID int, integrationKey []byte, webhookSecret string) (*GitHub, error) {
 	g := &GitHub{
 		analyser:       analyser,
 		db:             db,
-		queuer:         queuer,
+		queuePush:      queuePush,
 		webhookSecret:  []byte(webhookSecret),
 		integrationID:  integrationID,
 		integrationKey: integrationKey,

--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -39,11 +39,11 @@ func (g *GitHub) WebHookHandler(w http.ResponseWriter, r *http.Request) {
 		err = g.integrationInstallationEvent(e)
 	case *github.PushEvent:
 		log.Printf("github: push event: installation id: %v", *e.Installation.ID)
-		err = g.queuer.Queue(e)
+		g.queuePush <- e
 	case *github.PullRequestEvent:
 		if validPRAction(*e.Action) {
 			log.Printf("github: pull request event: %v, installation id: %v", *e.Action, *e.Installation.ID)
-			err = g.queuer.Queue(e)
+			g.queuePush <- e
 		}
 	default:
 		log.Printf("github: ignored webhook event: %T", event)

--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -84,10 +84,11 @@ func setup(t *testing.T) (*GitHub, *mockAnalyser, *db.MockDB) {
 		wg sync.WaitGroup
 		c  = make(chan interface{})
 	)
-	queue := queue.NewMemoryQueue(context.Background(), &wg, c)
+	queue := queue.NewMemoryQueue()
+	queue.Wait(context.Background(), &wg, c, func(job interface{}) {})
 
 	// New GitHub
-	g, err := New(mockAnalyser, memDB, queue, 1, integrationKey, webhookSecret)
+	g, err := New(mockAnalyser, memDB, c, 1, integrationKey, webhookSecret)
 	if err != nil {
 		t.Fatal("could not initialise GitHub:", err)
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,7 +1,0 @@
-package queue
-
-// Queuer pushes jobs onto a queue and pushes the next job on the provided
-// channel.
-type Queuer interface {
-	Queue(interface{}) error
-}


### PR DESCRIPTION
Google have recently made some breaking changes to their Pub/Sub
client API to support new high performance streaming methods.

https://groups.google.com/forum/#!topic/google-api-go-announce/aaqRDIQ3rvU/discussion
https://groups.google.com/forum/#!topic/google-api-go-announce/8pt6oetAdKc/discussion

The main change is the new methods don't easily support blocking
operations, nor one message at a time use cases. This is being
discussed: https://github.com/GoogleCloudPlatform/google-cloud-go/issues/566

This change attempts to use the new API but in a blocking method
indirectly discussed: https://github.com/GoogleCloudPlatform/google-cloud-go/issues/569

Since finishing and testing this method, which was successful, it
appears Google is discussing this use case further internally, so
this may not be the final solution, but gets us through for the moment.

If we're required to stop using the Pub/Sub client, and instead use
the APIv1 client, the issue does contain a gist of how it could work,
but it hasn't been tested in various failure modes, as it's a lower
level API - but I'm confident it just requires more testing and likely
no more changes.

Further, these changes did necessitate some refectoring on the internal
APIs, this was mostly opportunistic but made the changes simpler.

This refactors were essentially use a channel to push messages onto
the queue, previously this was an interface called Queuer. Also,
previously new jobs to be executed were sent on a channel, instead
each type of queuer should take a callback, and execute that callback
with the job as the only parameter.

A callback was chosen instead of another channel, as I wanted to ensure
only one message was consumed at a time, so the new APIs Receive method
has only one instance running, and calls the callback, blocking until
finished. When using a syncronous channel the Receive method became
asyncronous because it would unblock as soon as the message on the
channel was received, allowing the Receiver callback to fetch another
message - but then block as there was be no other listener on the channel.

GCPPubSubQueue was tested to ensure only one message is removed from
the queue at any time, allowing other instances to consume the remaining
messages, and on shutdown the executing job is allowed to finish in
full before the process exits.

Note to self, vendor dependencies.