### PR TITLE
Write analysis to the database

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -14,9 +14,26 @@ type DB interface {
 	// ListTools returns all tools. Returns nil if no tools were found, error will
 	// be non-nil if an error occurs.
 	ListTools() ([]Tool, error)
+	// StartAnalysis records a new analysis.
+	StartAnalysis(ghInstallationID, repositoryID int) (analysisID int, err error)
+	// FinishAnalysis marks a status as finished.
+	FinishAnalysis(analysisID int, status AnalysisStatus, analysis *Analysis) error
 }
 
+// AnalysisStatus represents a status in the analysis table.
+type AnalysisStatus string
+
+// AnalysisStatus type/enum mappings to the analysis table.
+const (
+	AnalysisStatusPending AnalysisStatus = "Pending" // Analysis is pending/started (not finished/completed).
+	AnalysisStatusFailure AnalysisStatus = "Failure" // Analysis is marked as failed.
+	AnalysisStatusSuccess AnalysisStatus = "Success" // Analysis is marked as successful.
+	AnalysisStatusError   AnalysisStatus = "Error"   // Analysis failed due to an internal error.
+)
+
+// GHInstallation represents a row from the gh_installations table.
 type GHInstallation struct {
+	ID             int
 	InstallationID int
 	AccountID      int
 	SenderID       int
@@ -28,12 +45,63 @@ func (i GHInstallation) IsEnabled() bool {
 	return i.enabledAt.Before(time.Now()) && !i.enabledAt.IsZero()
 }
 
-// Tool represents a single tool
+// ToolID is the primary key on the tools table.
+type ToolID int
+
+// Tool represents a single tool in the tools table.
 type Tool struct {
-	ID     int    `db:"id"`
+	ID     ToolID `db:"id"`
 	Name   string `db:"name"`
 	URL    string `db:"url"`
 	Path   string `db:"path"`
 	Args   string `db:"args"`
 	Regexp string `db:"regexp"`
+}
+
+// Analysis represents a single analysis of a repository at a point in time.
+type Analysis struct {
+	ID               int            `db:"id"`
+	GHInstallationID int            `db:"gh_installation_id"`
+	RepositoryID     int            `db:"repository_id"`
+	Status           AnalysisStatus `db:"status"`
+
+	// When an analysis is finished
+	CloneDuration time.Duration `db:"clone_duration"` // CloneDuration is the wall clock time taken to run clone.
+	DepsDuration  time.Duration `db:"deps_duration"`  // DepsDuration is the wall clock time taken to fetch dependencies.
+	TotalDuration time.Duration `db:"total_duration"` // TotalDuration is the wall clock time taken for the entire analysis.
+	Tools         map[ToolID]AnalysisTool
+}
+
+// NewAnalysis returns a ready to use analysis.
+func NewAnalysis() *Analysis {
+	return &Analysis{
+		Tools: make(map[ToolID]AnalysisTool),
+	}
+}
+
+// Issues returns all the issues by each tool as a slice.
+func (a *Analysis) Issues() []Issue {
+	var issues []Issue
+	for _, tool := range a.Tools {
+		issues = append(issues, tool.Issues...)
+	}
+	return issues
+}
+
+// AnalysisTool contains the timing and result of an individual tool's analysis.
+type AnalysisTool struct {
+	Duration time.Duration // Duration is the wall clock time taken to run the tool.
+	Issues   []Issue       // Issues maybe nil if no issues found.
+}
+
+// Issue contains file, position and string describing a single issue.
+type Issue struct {
+	// Path is the relative path name of the file.
+	Path string
+	// Line is the line number of the file.
+	Line int
+	// HunkPos is the position relative to the files first hunk.
+	HunkPos int
+	// Issue is the issue.
+	Issue string // maybe this should be issue
 }

--- a/internal/db/mockdb.go
+++ b/internal/db/mockdb.go
@@ -60,3 +60,13 @@ func (db *MockDB) GetGHInstallation(installationID int) (*GHInstallation, error)
 func (db *MockDB) ListTools() ([]Tool, error) {
 	return db.Tools, nil
 }
+
+// StartAnalysis implements the DB interface.
+func (db *MockDB) StartAnalysis(ghInstallationID, repositoryID int) (int, error) {
+	return 0, nil
+}
+
+// FinishAnalysis implements the DB interface.
+func (db *MockDB) FinishAnalysis(analysisID int, status AnalysisStatus, analysis *Analysis) error {
+	return nil
+}

--- a/internal/db/sqldb.go
+++ b/internal/db/sqldb.go
@@ -2,20 +2,21 @@ package db
 
 import (
 	"database/sql"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 )
 
-// SQLDB is a sql database repository implementing the DB interface
+// SQLDB is a sql database repository implementing the DB interface.
 type SQLDB struct {
 	sqlx *sqlx.DB
 }
 
-// Ensure SQLDB implements DB
+// Ensure SQLDB implements DB.
 var _ DB = (*SQLDB)(nil)
 
-// NewSQLDB returns an SQLDB
+// NewSQLDB returns an SQLDB.
 func NewSQLDB(sqlDB *sql.DB, driverName string) (*SQLDB, error) {
 	db := &SQLDB{
 		sqlx: sqlx.NewDb(sqlDB, driverName),
@@ -26,7 +27,7 @@ func NewSQLDB(sqlDB *sql.DB, driverName string) (*SQLDB, error) {
 	return db, nil
 }
 
-// AddGHInstallation implements DB interface
+// AddGHInstallation implements the DB interface.
 func (db *SQLDB) AddGHInstallation(installationID, accountID, senderID int) error {
 	// INSERT IGNORE so any duplicates are ignored
 	_, err := db.sqlx.Exec("INSERT IGNORE INTO gh_installations (installation_id, account_id, sender_id) VALUES (?, ?, ?)",
@@ -35,21 +36,22 @@ func (db *SQLDB) AddGHInstallation(installationID, accountID, senderID int) erro
 	return err
 }
 
-// RemoveGHInstallation implements DB interface
+// RemoveGHInstallation implements the DB interface.
 func (db *SQLDB) RemoveGHInstallation(installationID int) error {
 	_, err := db.sqlx.Exec("DELETE FROM gh_installations WHERE installation_id = ?", installationID)
 	return err
 }
 
-// GetGHInstallation implements DB interface
+// GetGHInstallation implements the DB interface.
 func (db *SQLDB) GetGHInstallation(installationID int) (*GHInstallation, error) {
 	var row struct {
+		ID             int            `db:"id"`
 		InstallationID int            `db:"installation_id"`
 		AccountID      int            `db:"account_id"`
 		SenderID       int            `db:"sender_id"`
 		EnabledAt      mysql.NullTime `db:"enabled_at"`
 	}
-	err := db.sqlx.Get(&row, "SELECT installation_id, account_id, sender_id, enabled_at FROM gh_installations WHERE installation_id = ?", installationID)
+	err := db.sqlx.Get(&row, "SELECT id, installation_id, account_id, sender_id, enabled_at FROM gh_installations WHERE installation_id = ?", installationID)
 	switch {
 	case err == sql.ErrNoRows:
 		return nil, nil
@@ -57,6 +59,7 @@ func (db *SQLDB) GetGHInstallation(installationID int) (*GHInstallation, error) 
 		return nil, err
 	}
 	ghi := &GHInstallation{
+		ID:             row.ID,
 		InstallationID: row.InstallationID,
 		AccountID:      row.AccountID,
 		SenderID:       row.SenderID,
@@ -67,8 +70,52 @@ func (db *SQLDB) GetGHInstallation(installationID int) (*GHInstallation, error) 
 	return ghi, nil
 }
 
+// ListTools implements the DB interface.
 func (db *SQLDB) ListTools() ([]Tool, error) {
 	var tools []Tool
-	err := db.sqlx.Select(&tools, "SELECT name, path, args, `regexp` FROM tools")
+	err := db.sqlx.Select(&tools, "SELECT id, name, path, args, `regexp` FROM tools")
 	return tools, err
+}
+
+// StartAnalysis implements the DB interface.
+func (db *SQLDB) StartAnalysis(ghInstallationID, repositoryID int) (int, error) {
+	result, err := db.sqlx.Exec("INSERT INTO analysis (gh_installation_id, repository_id) VALUES (?, ?)", ghInstallationID, repositoryID)
+	if err != nil {
+		return 0, err
+	}
+	analysisID, err := result.LastInsertId()
+	return int(analysisID), err
+}
+
+// FinishAnalysis implements the DB interface.
+func (db *SQLDB) FinishAnalysis(analysisID int, status AnalysisStatus, analysis *Analysis) error {
+	if analysis == nil {
+		_, err := db.sqlx.Exec("UPDATE analysis SET status = ? WHERE id = ?", string(status), analysisID)
+		return err
+	}
+	_, err := db.sqlx.Exec("UPDATE analysis SET status = ?, clone_duration = ?, deps_duration = ?, total_duration = ? WHERE id = ?",
+		string(status), analysis.CloneDuration/time.Second, analysis.DepsDuration/time.Second, analysis.TotalDuration/time.Second, analysisID,
+	)
+	if err != nil {
+		return err
+	}
+	for toolID, tool := range analysis.Tools {
+		toolResult, err := db.sqlx.Exec("INSERT INTO analysis_tool (analysis_id, tool_id, duration) VALUES (?, ?, ?)", analysisID, toolID, tool.Duration/time.Second)
+		if err != nil {
+			return err
+		}
+
+		toolAnalysisID, err := toolResult.LastInsertId()
+		if err != nil {
+			return err
+		}
+
+		for _, issue := range tool.Issues {
+			db.sqlx.Exec("INSERT INTO issues (analysis_tool_id, filename, line, hunk_pos, issue) VALUES(?, ?, ?, ?, ?)",
+				toolAnalysisID, issue.Path, issue.Line, issue.HunkPos, issue.Issue,
+			)
+		}
+
+	}
+	return nil
 }

--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -182,6 +182,7 @@ func TestPushConfig(t *testing.T) {
 	want := AnalyseConfig{
 		eventType:       analyser.EventTypePush,
 		installationID:  1,
+		repositoryID:    2,
 		statusesContext: "ci/gopherci/push",
 		statusesURL:     "https://github.com/owner/repo/status/abcdef",
 		baseURL:         "https://github.com/owner/repo.git",
@@ -195,6 +196,7 @@ func TestPushConfig(t *testing.T) {
 			ID: github.Int(1),
 		},
 		Repo: &github.PushEventRepository{
+			ID:          github.Int(2),
 			StatusesURL: github.String("https://github.com/owner/repo/status/{sha}"),
 			CloneURL:    github.String("https://github.com/owner/repo.git"),
 			HTMLURL:     github.String("https://github.com/owner/repo"),
@@ -214,6 +216,7 @@ func TestPullRequestConfig(t *testing.T) {
 	want := AnalyseConfig{
 		eventType:       analyser.EventTypePullRequest,
 		installationID:  1,
+		repositoryID:    2,
 		statusesContext: "ci/gopherci/pr",
 		statusesURL:     "https://github.com/owner/repo/status/abcdef",
 		baseURL:         "https://github.com/owner/repo.git",
@@ -252,6 +255,9 @@ func TestPullRequestConfig(t *testing.T) {
 		},
 		Installation: &github.Installation{
 			ID: github.Int(1),
+		},
+		Repo: &github.Repository{
+			ID: github.Int(2),
 		},
 	}
 	have := PullRequestConfig(e)
@@ -442,15 +448,15 @@ func TestStripScheme(t *testing.T) {
 
 func TestStatusDesc(t *testing.T) {
 	tests := []struct {
-		issues     []analyser.Issue
+		issues     []db.Issue
 		suppressed int
 		want       string
 	}{
-		{[]analyser.Issue{{}, {}}, 2, "Found 2 issues (2 comments suppressed)"},
-		{[]analyser.Issue{{}, {}}, 1, "Found 2 issues (1 comment suppressed)"},
-		{[]analyser.Issue{{}, {}}, 0, "Found 2 issues"},
-		{[]analyser.Issue{{}}, 0, "Found 1 issue"},
-		{[]analyser.Issue{}, 0, `Found no issues \ʕ◔ϖ◔ʔ/`},
+		{[]db.Issue{{}, {}}, 2, "Found 2 issues (2 comments suppressed)"},
+		{[]db.Issue{{}, {}}, 1, "Found 2 issues (1 comment suppressed)"},
+		{[]db.Issue{{}, {}}, 0, "Found 2 issues"},
+		{[]db.Issue{{}}, 0, "Found 1 issue"},
+		{[]db.Issue{}, 0, `Found no issues \ʕ◔ϖ◔ʔ/`},
 	}
 
 	for _, test := range tests {

--- a/internal/github/installation_test.go
+++ b/internal/github/installation_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bradleyfalzon/gopherci/internal/analyser"
+	"github.com/bradleyfalzon/gopherci/internal/db"
 	"github.com/google/go-github/github"
 )
 
@@ -25,9 +25,9 @@ func TestFilterIssues_maxIssueComments(t *testing.T) {
 	suppress := 1
 
 	// Add more issues than maxIssueComments
-	var issues []analyser.Issue
+	var issues []db.Issue
 	for n := 0; n < maxIssueComments+suppress; n++ {
-		issues = append(issues, analyser.Issue{File: "file.go", HunkPos: n, Issue: "body"})
+		issues = append(issues, db.Issue{Path: "file.go", HunkPos: n, Issue: "body"})
 	}
 
 	suppressed, filtered, err := i.FilterIssues(context.Background(), "owner", "repo", 2, issues)
@@ -85,10 +85,10 @@ func TestFilterIssues_deduplicate(t *testing.T) {
 	i := Installation{client: github.NewClient(nil)}
 	i.client.BaseURL, _ = url.Parse(ts.URL)
 
-	var issues = []analyser.Issue{
-		{File: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody},     // remove
-		{File: expectedCmtPath, HunkPos: expectedCmtPos + 1, Issue: expectedCmtBody}, // keep
-		{File: expectedCmtPath, HunkPos: expectedCmtPos + 2, Issue: expectedCmtBody}, // remove
+	var issues = []db.Issue{
+		{Path: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody},     // remove
+		{Path: expectedCmtPath, HunkPos: expectedCmtPos + 1, Issue: expectedCmtBody}, // keep
+		{Path: expectedCmtPath, HunkPos: expectedCmtPos + 2, Issue: expectedCmtBody}, // remove
 	}
 
 	_, filtered, err := i.FilterIssues(context.Background(), expectedOwner, expectedRepo, expectedPR, issues)
@@ -139,7 +139,7 @@ func TestWriteIssues(t *testing.T) {
 	i := Installation{client: github.NewClient(nil)}
 	i.client.BaseURL, _ = url.Parse(ts.URL)
 
-	var issues = []analyser.Issue{{File: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody}}
+	var issues = []db.Issue{{Path: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody}}
 
 	err := i.WriteIssues(context.Background(), expectedOwner, expectedRepo, expectedPR, expectedCmtSHA, issues)
 	if err != nil {

--- a/migrations/4_analysis.sql
+++ b/migrations/4_analysis.sql
@@ -1,0 +1,44 @@
+-- +migrate Up
+CREATE TABLE analysis (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    gh_installation_id INT UNSIGNED NOT NULL,
+    repository_id INT UNSIGNED,
+    status ENUM("Pending", "Failure", "Success", "Error") DEFAULT "Pending",
+    clone_duration TIME(3) NULL DEFAULT NULL,
+    deps_duration TIME(3) NULL DEFAULT NULL,
+    total_duration TIME(3) NULL DEFAULT NULL,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY (gh_installation_id),
+    KEY (repository_id),
+    FOREIGN KEY (gh_installation_id) REFERENCES gh_installations(id) ON DELETE CASCADE
+);
+
+CREATE TABLE analysis_tool (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    analysis_id INT UNSIGNED NOT NULL,
+    tool_id INT UNSIGNED NOT NULL,
+    duration TIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    KEY (analysis_id),
+    KEY (tool_id),
+    FOREIGN KEY (analysis_id) REFERENCES analysis(id) ON DELETE CASCADE,
+    FOREIGN KEY (tool_id) REFERENCES tools(id) ON DELETE CASCADE
+);
+
+CREATE TABLE issues (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    analysis_tool_id INT UNSIGNED NOT NULL,
+    path VARCHAR(255) NOT NULL,
+    line INT UNSIGNED NOT NULL,
+    hunk_pos INT UNSIGNED NOT NULL,
+    issue TEXT,
+    PRIMARY KEY (id),
+    KEY (analysis_tool_id),
+    FOREIGN KEY (analysis_tool_id) REFERENCES analysis_tool(id) ON DELETE CASCADE
+);
+
+-- +migrate Down
+DROP TABLE issues;
+DROP TABLE analysis_tool;
+DROP TABLE analysis;


### PR DESCRIPTION
This provides the foundations for a web view (discussed in #28),
so users can view the issues without relying on inline or issue
comments.

This also provides a mechanism to time how long the analysis is
taking as well as a per tool timing metric. This allows us to better
understand how much time different repositories or installations spend
checking.

We record which tools were executed, even if no issues were detected
so the user knows which checks passed. This will cause the analysis_tool
table to become very large over time.

Relates to #3.