### PR TITLE
Working web UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# URL prefix for GopherCI to refer back to itself, without trailing slash.
+GCI_BASE_URL=https://gci.gopherci.io
+
 # GitHub Integration ID provided when creating the integration
 GITHUB_ID=
 

--- a/internal/analyser/analyser_test.go
+++ b/internal/analyser/analyser_test.go
@@ -88,7 +88,10 @@ index 0000000..6362395
 		},
 	}
 
-	analysis, err := Analyse(context.Background(), analyser, tools, cfg)
+	mockDB := db.NewMockDB()
+	analysis, _ := mockDB.StartAnalysis(1, 2)
+
+	err := Analyse(context.Background(), analyser, tools, cfg, analysis)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -182,7 +185,10 @@ index 0000000..6362395
 		},
 	}
 
-	analysis, err := Analyse(context.Background(), analyser, tools, cfg)
+	mockDB := db.NewMockDB()
+	analysis, _ := mockDB.StartAnalysis(1, 2)
+
+	err := Analyse(context.Background(), analyser, tools, cfg, analysis)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -227,7 +233,11 @@ index 0000000..6362395
 func TestAnalyse_unknown(t *testing.T) {
 	cfg := Config{}
 	analyser := &mockAnalyser{}
-	_, err := Analyse(context.Background(), analyser, nil, cfg)
+
+	mockDB := db.NewMockDB()
+	analysis, _ := mockDB.StartAnalysis(1, 2)
+
+	err := Analyse(context.Background(), analyser, nil, cfg, analysis)
 	if err == nil {
 		t.Fatal("expected error got nil")
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,6 +1,11 @@
 package db
 
-import "time"
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"time"
+)
 
 // DB interface provides access to a persistent database.
 type DB interface {
@@ -15,9 +20,12 @@ type DB interface {
 	// be non-nil if an error occurs.
 	ListTools() ([]Tool, error)
 	// StartAnalysis records a new analysis.
-	StartAnalysis(ghInstallationID, repositoryID int) (analysisID int, err error)
+	StartAnalysis(ghInstallationID, repositoryID int) (*Analysis, error)
 	// FinishAnalysis marks a status as finished.
 	FinishAnalysis(analysisID int, status AnalysisStatus, analysis *Analysis) error
+	// GetAnalysis returns an analysis for a given analysisID, returns nil if no
+	// analysis was found, or an error occurs.
+	GetAnalysis(analysisID int) (*Analysis, error)
 }
 
 // AnalysisStatus represents a status in the analysis table.
@@ -30,6 +38,29 @@ const (
 	AnalysisStatusSuccess AnalysisStatus = "Success" // Analysis is marked as successful.
 	AnalysisStatusError   AnalysisStatus = "Error"   // Analysis failed due to an internal error.
 )
+
+var errUnknownAnalysis = errors.New("unknown analysis status")
+
+// Scan implements the sql.Scanner interface.
+func (s *AnalysisStatus) Scan(value interface{}) error {
+	if value == nil {
+		*s = AnalysisStatusPending
+		return nil
+	}
+	switch string(value.([]uint8)) {
+	case "Pending":
+		*s = AnalysisStatusPending
+	case "Failure":
+		*s = AnalysisStatusFailure
+	case "Success":
+		*s = AnalysisStatusSuccess
+	case "Error":
+		*s = AnalysisStatusError
+	default:
+		return errUnknownAnalysis
+	}
+	return nil
+}
 
 // GHInstallation represents a row from the gh_installations table.
 type GHInstallation struct {
@@ -58,17 +89,45 @@ type Tool struct {
 	Regexp string `db:"regexp"`
 }
 
+// Duration is similar to a time.Duration but with extra methods to better
+// handle mysql DB type TIME(3).
+type Duration int64
+
+// Scan implements the sql.Scanner interface.
+func (d *Duration) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	t, err := time.Parse("15:04:05.999999999", string(value.([]uint8)))
+	if err != nil {
+		return err
+	}
+	*d = Duration(t.AddDate(1970, 0, 0).UnixNano())
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (d Duration) Value() (driver.Value, error) {
+	return float64(d) / float64(time.Second), nil
+}
+
+// String implements the fmt.Stringer interface.
+func (d Duration) String() string {
+	return time.Duration(d).String()
+}
+
 // Analysis represents a single analysis of a repository at a point in time.
 type Analysis struct {
 	ID               int            `db:"id"`
 	GHInstallationID int            `db:"gh_installation_id"`
 	RepositoryID     int            `db:"repository_id"`
 	Status           AnalysisStatus `db:"status"`
+	CreatedAt        time.Time      `db:"created_at"`
 
 	// When an analysis is finished
-	CloneDuration time.Duration `db:"clone_duration"` // CloneDuration is the wall clock time taken to run clone.
-	DepsDuration  time.Duration `db:"deps_duration"`  // DepsDuration is the wall clock time taken to fetch dependencies.
-	TotalDuration time.Duration `db:"total_duration"` // TotalDuration is the wall clock time taken for the entire analysis.
+	CloneDuration Duration `db:"clone_duration"` // CloneDuration is the wall clock time taken to run clone.
+	DepsDuration  Duration `db:"deps_duration"`  // DepsDuration is the wall clock time taken to fetch dependencies.
+	TotalDuration Duration `db:"total_duration"` // TotalDuration is the wall clock time taken for the entire analysis.
 	Tools         map[ToolID]AnalysisTool
 }
 
@@ -88,10 +147,17 @@ func (a *Analysis) Issues() []Issue {
 	return issues
 }
 
+// HTMLURL returns the URL to view the analysis.
+func (a *Analysis) HTMLURL(prefix string) string {
+	return fmt.Sprintf("%s/analysis/%d", prefix, a.ID)
+}
+
 // AnalysisTool contains the timing and result of an individual tool's analysis.
 type AnalysisTool struct {
-	Duration time.Duration // Duration is the wall clock time taken to run the tool.
-	Issues   []Issue       // Issues maybe nil if no issues found.
+	Tool     *Tool    // Tool is the tool.
+	ToolID   ToolID   // ToolID is the ID of the tool.
+	Duration Duration // Duration is the wall clock time taken to run the tool.
+	Issues   []Issue  // Issues maybe nil if no issues found.
 }
 
 // Issue contains file, position and string describing a single issue.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAnalysisStatus_scan(t *testing.T) {
+	tests := []struct {
+		input interface{}
+		want  AnalysisStatus
+		err   error
+	}{
+		{nil, AnalysisStatusPending, nil},
+		{[]uint8("Pending"), AnalysisStatusPending, nil},
+		{[]uint8("Failure"), AnalysisStatusFailure, nil},
+		{[]uint8("Success"), AnalysisStatusSuccess, nil},
+		{[]uint8("Error"), AnalysisStatusError, nil},
+		{[]uint8("NA"), "", errUnknownAnalysis},
+	}
+
+	for _, test := range tests {
+		var status AnalysisStatus
+		err := status.Scan(test.input)
+		if err != test.err {
+			t.Errorf("unexpected error: have: %v want: %v", err, test.err)
+		}
+		if status != test.want {
+			t.Errorf("input: %#v have: %#v want %#v", test.input, status, test.want)
+		}
+	}
+}
+
+func TestDuration_scan(t *testing.T) {
+	tests := []struct {
+		input   interface{}
+		want    Duration
+		isError bool
+	}{
+		{nil, 0, false},
+		{[]uint8("01:02:03"), Duration(1*time.Hour + 2*time.Minute + 3*time.Second), false},
+		{[]uint8("00:00:03.100"), Duration(3*time.Second + 100*time.Millisecond), false},
+		{[]uint8("unknown format"), 0, true},
+	}
+
+	for _, test := range tests {
+		var d Duration
+		err := d.Scan(test.input)
+		if err != nil && !test.isError || err == nil && test.isError {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if d != test.want {
+			t.Errorf("input: %s have: %#v want %#v", test.input, d, test.want)
+		}
+	}
+}
+
+func TestDuration_value(t *testing.T) {
+	want := 1.100
+	have, err := Duration(time.Second + 100*time.Millisecond).Value()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if have != want {
+		t.Errorf("have: %v, want: %v", have, want)
+	}
+}
+
+func TestDuration_string(t *testing.T) {
+	want := time.Duration(100).String()
+	have := Duration(100).String()
+	if have != want {
+		t.Errorf("have: %v, want: %v", have, want)
+	}
+}

--- a/internal/db/mockdb.go
+++ b/internal/db/mockdb.go
@@ -62,11 +62,18 @@ func (db *MockDB) ListTools() ([]Tool, error) {
 }
 
 // StartAnalysis implements the DB interface.
-func (db *MockDB) StartAnalysis(ghInstallationID, repositoryID int) (int, error) {
-	return 0, nil
+func (db *MockDB) StartAnalysis(ghInstallationID, repositoryID int) (*Analysis, error) {
+	analysis := NewAnalysis()
+	analysis.ID = 99
+	return analysis, nil
 }
 
 // FinishAnalysis implements the DB interface.
 func (db *MockDB) FinishAnalysis(analysisID int, status AnalysisStatus, analysis *Analysis) error {
 	return nil
+}
+
+// GetAnalysis implements the DB interface.
+func (db *MockDB) GetAnalysis(analysisID int) (*Analysis, error) {
+	return nil, nil
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -18,6 +18,7 @@ type GitHub struct {
 	integrationKey []byte            // integrationKey is the private key for the installationID
 	tr             http.RoundTripper // tr is a transport shared by all installations to reuse http connections
 	baseURL        string            // baseURL for GitHub API
+	gciBaseURL     string            // gciBaseURL is the base URL for GopherCI
 }
 
 // New returns a GitHub object for use with GitHub integrations
@@ -25,7 +26,7 @@ type GitHub struct {
 // integrationID is the GitHub Integration ID (not installation ID).
 // integrationKey is the key for the integrationID provided to you by GitHub
 // during the integration registration.
-func New(analyser analyser.Analyser, db db.DB, queuePush chan<- interface{}, integrationID int, integrationKey []byte, webhookSecret string) (*GitHub, error) {
+func New(analyser analyser.Analyser, db db.DB, queuePush chan<- interface{}, integrationID int, integrationKey []byte, webhookSecret, gciBaseURL string) (*GitHub, error) {
 	g := &GitHub{
 		analyser:       analyser,
 		db:             db,
@@ -35,6 +36,7 @@ func New(analyser analyser.Analyser, db db.DB, queuePush chan<- interface{}, int
 		integrationKey: integrationKey,
 		tr:             http.DefaultTransport,
 		baseURL:        "https://api.github.com",
+		gciBaseURL:     gciBaseURL,
 	}
 
 	// TODO some prechecks should be done now, instead of later, fail fast/early.

--- a/internal/github/installation.go
+++ b/internal/github/installation.go
@@ -64,14 +64,14 @@ const (
 )
 
 // SetStatus sets the CI Status API
-func (i *Installation) SetStatus(ctx context.Context, context, statusURL string, status StatusState, description string) error {
+func (i *Installation) SetStatus(ctx context.Context, context, statusURL string, status StatusState, description, targetURL string) error {
 	s := struct {
 		State       string `json:"state,omitempty"`
 		TargetURL   string `json:"target_url,omitempty"`
 		Description string `json:"description,omitempty"`
 		Context     string `json:"context,omitempty"`
 	}{
-		string(status), "", description, context,
+		string(status), targetURL, description, context,
 	}
 	log.Printf("status: %#v", status)
 

--- a/internal/web/templates/analysis.tmpl
+++ b/internal/web/templates/analysis.tmpl
@@ -1,0 +1,68 @@
+{{ template "header" . }}
+
+<div class="container">
+    <h1>Analysis</h1>
+
+
+    {{ with .Analysis }}
+        <table class="table">
+            <tbody>
+                <tr>
+                    <th>Started</th><td>{{ .CreatedAt }}</td>
+                </tr>
+                <tr>
+                    <th>Status</th>
+                    <td>
+                        {{ if eq .Status "Success" }}
+                            <span class="badge badge-success">{{ .Status }}</span>
+                            <button type="button" class="btn btn-outline-danger btn-sm">Mark as Failure</button>
+                        {{ else if eq .Status "Failure" }}
+                            <span class="badge badge-danger">{{ .Status }}</span>
+                            <button type="button" class="btn btn-outline-success btn-sm">Mark as Success</button>
+                        {{ else if eq .Status "Error" }}
+                            <span class="badge badge-warning">{{ .Status }}</span>
+                            <button type="button" class="btn btn-outline-success btn-sm">Mark as Success</button>
+                        {{ else }}
+                            <span class="badge badge-default">{{ .Status }}</span>
+                        {{ end }}
+
+                        <button type="button" class="btn btn-secondary btn-sm">Rerun Analysis</button>
+                    </td>
+                </tr>
+                {{ if ne .Status "Pending" }}
+                    <tr>
+                        <th>Clone Duration</th><td>{{ .CloneDuration }}</td>
+                    </tr>
+                    <tr>
+                        <th>Deps Duration</th><td>{{ .DepsDuration }}</td>
+                    </tr>
+                    <tr>
+                        <th>Total Duration</th><td>{{ .TotalDuration }}</td>
+                    </tr>
+                {{ end }}
+            </tbody>
+        </table>
+
+
+
+        <div class="section">
+            {{ range .Tools }}
+                <h3><a href="{{.Tool.URL}}">{{ .Tool.Name }}</a></h3>
+                <p>Found {{ len .Issues }} issues in {{ .Duration }}.</p>
+                {{ if .Issues }}
+                    <table class="table">
+                        <tbody>
+                            {{ range .Issues }}
+                                <tr><td>{{ .Path }}:{{ .Line }} {{ .Issue }}</td></tr>
+                            {{ end }}
+                        </tbody>
+                    </table>
+                {{ end }}
+            {{ end }}
+        </div>
+    {{ end }}
+</div>
+<hr>
+
+</div>
+{{ template "footer" . }}

--- a/internal/web/templates/error.tmpl
+++ b/internal/web/templates/error.tmpl
@@ -1,0 +1,9 @@
+{{ template "header" . }}
+
+<ul>
+    <li>Code: {{ .Code }}</li>
+    <li>Text: {{ .Status }}</li>
+    <li>Desc: {{ .Desc }}</li>
+</ul>
+
+{{ template "footer" . }}

--- a/internal/web/templates/footer.tmpl
+++ b/internal/web/templates/footer.tmpl
@@ -1,0 +1,11 @@
+{{define "footer"}}
+<footer class="footer">
+    <div class="container">
+        <div class="content has-text-centered">
+            <p><a href="https://github.com/bradleyfalzon/gopherci">GitHub</a></p>
+        </div>
+    </div>
+</footer>
+</body>
+</html>
+{{end}}

--- a/internal/web/templates/header.tmpl
+++ b/internal/web/templates/header.tmpl
@@ -1,0 +1,13 @@
+{{define "header" -}}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+        <link rel="stylesheet" href="/static/site.css">
+        <title>{{ if .Title }}{{ .Title }} - {{ end }}GopherCI</title>
+    </head>
+    <body>
+{{end}}
+

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -1,0 +1,91 @@
+package web
+
+import (
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/pressly/chi"
+)
+
+// Web handles general web/html responses (not API hooks).
+type Web struct {
+	db        db.DB
+	templates *template.Template
+}
+
+// NewWeb returns a new Web instance, or an error.
+func NewWeb(db db.DB) (*Web, error) {
+	// Initialise html templates
+	templates, err := template.ParseGlob("internal/web/templates/*.tmpl")
+	if err != nil {
+		return nil, err
+	}
+
+	web := &Web{
+		db:        db,
+		templates: templates,
+	}
+	return web, nil
+}
+
+// NotFoundHandler displays a 404 not found error
+func (web *Web) NotFoundHandler(w http.ResponseWriter, r *http.Request) {
+	web.errorHandler(w, r, http.StatusNotFound, fmt.Sprintf("%q not found", r.URL))
+}
+
+// errorHandler handles an error message, with an optional description
+func (web *Web) errorHandler(w http.ResponseWriter, r *http.Request, code int, desc string) {
+	page := struct {
+		Title  string
+		Code   string // eg 400
+		Status string // eg Bad Request
+		Desc   string // eg Missing key foo
+	}{fmt.Sprintf("%d - %s", code, http.StatusText(code)), strconv.Itoa(code), http.StatusText(code), desc}
+
+	if page.Desc == "" {
+		page.Desc = http.StatusText(code)
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(code)
+	if err := web.templates.ExecuteTemplate(w, "error.tmpl", page); err != nil {
+		log.Println("error parsing error template:", err)
+	}
+}
+
+// AnalysisHandler displays a single analysis.
+func (web *Web) AnalysisHandler(w http.ResponseWriter, r *http.Request) {
+	analysisID, err := strconv.ParseInt(chi.URLParam(r, "analysisID"), 10, 32)
+	if err != nil {
+		web.errorHandler(w, r, http.StatusBadRequest, "Invalid analysis ID")
+		return
+	}
+
+	analysis, err := web.db.GetAnalysis(int(analysisID))
+	if err != nil {
+		log.Printf("error getting analysisID %v: %v", analysisID, err)
+		web.errorHandler(w, r, http.StatusInternalServerError, "Could not get analysis")
+		return
+	}
+
+	if analysis == nil {
+		web.NotFoundHandler(w, r)
+		return
+	}
+
+	var page = struct {
+		Title    string
+		Analysis *db.Analysis
+	}{
+		Title:    "Analysis",
+		Analysis: analysis,
+	}
+
+	if err := web.templates.ExecuteTemplate(w, "analysis.tmpl", page); err != nil {
+		log.Printf("error parsing analysis template: %v", err)
+	}
+}


### PR DESCRIPTION
GopherCI itself has the ability to show the results of an analysis.
This is the first version, very rough cut.

It's achieved by creating an internal package web, containing static
assets, templates and the handlers for the web views. This is done
to best compartmentalise the web components from the CI checks as
much as possible, as GopherCI is a CI tool, not a web view into the
results. I don't imagine too much more functionality being added
that isn't directly related to viewing analysis results.

Additional changes were required, there was a bug when writing results
to the database, it was using a TIME(3) field but trying to store
seconds in it, so results above 60 failed. The new Duration field
resolves this, and cleans up the marshalling of dates in and out of the
database. AnalysisStatus also implements sql.Scanner, so it can easily
be read from the database.

db.StartAnalysis now returns a db.Analysis with zero values zero for
all members except ID which is set correctly. Analyser now accepts
a pointer to a db.Analysis and it will populate the members as required.
This was done to allow the initial github SetStatus call to set the
HTML URL of the analysis. So when the status API is set the first time
a user can view and access the results.

Included is some changes to the GitHub CallbackHandler, it seems to be
deprecated, but because we had it set initially (I never used it),
GitHub still redirects users to this URL to then be redirected to the
analysis page. A small change was made to continue handling those
redirects and avoiding being an open redirect as well.

The web template itself is a very very rough draft, more work will
be made, but initially I just wanted a basic working version so lay
good foundations to focus on the UI at a later stage. It looks terrible,
but we'll address that later.