### PR TITLE
View a diff of the changes in the analysis view

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -118,11 +118,14 @@ func (d Duration) String() string {
 
 // Analysis represents a single analysis of a repository at a point in time.
 type Analysis struct {
-	ID               int            `db:"id"`
-	GHInstallationID int            `db:"gh_installation_id"`
-	RepositoryID     int            `db:"repository_id"`
-	Status           AnalysisStatus `db:"status"`
-	CreatedAt        time.Time      `db:"created_at"`
+	ID             int            `db:"id"`
+	InstallationID int            `db:"installation_id"`
+	RepositoryID   int            `db:"repository_id"`
+	CommitFrom     string         `db:"commit_from"`
+	CommitTo       string         `db:"commit_to"`
+	RequestNumber  int            `db:"request_number"`
+	Status         AnalysisStatus `db:"status"`
+	CreatedAt      time.Time      `db:"created_at"`
 
 	// When an analysis is finished
 	CloneDuration Duration `db:"clone_duration"` // CloneDuration is the wall clock time taken to run clone.
@@ -150,6 +153,12 @@ func (a *Analysis) Issues() []Issue {
 // HTMLURL returns the URL to view the analysis.
 func (a *Analysis) HTMLURL(prefix string) string {
 	return fmt.Sprintf("%s/analysis/%d", prefix, a.ID)
+}
+
+// IsPush returns true if the analysis was triggered by a push, or false if it
+// was triggered by pull/merge request.
+func (a *Analysis) IsPush() bool {
+	return a.RequestNumber == 0
 }
 
 // AnalysisTool contains the timing and result of an individual tool's analysis.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -71,5 +73,52 @@ func TestDuration_string(t *testing.T) {
 	have := Duration(100).String()
 	if have != want {
 		t.Errorf("have: %v, want: %v", have, want)
+	}
+}
+
+func TestAnalysis_issues(t *testing.T) {
+	analysis := NewAnalysis()
+	analysis.Tools[1] = AnalysisTool{
+		Issues: []Issue{{Issue: "issue"}},
+	}
+	analysis.Tools[2] = AnalysisTool{
+		Issues: []Issue{{Issue: "issue"}},
+	}
+
+	want := []Issue{{Issue: "issue"}, {Issue: "issue"}}
+	if have := analysis.Issues(); !reflect.DeepEqual(have, want) {
+		t.Errorf("\nhave: %#v\nwant: %#v", have, want)
+	}
+}
+
+func TestAnalysis_htmlurl(t *testing.T) {
+	analysis := NewAnalysis()
+	analysis.ID = 10
+	want := fmt.Sprintf("https://example.com/analysis/%d", analysis.ID)
+	if have := analysis.HTMLURL("https://example.com"); have != want {
+		t.Errorf("have: %q, want: %q", have, want)
+	}
+}
+
+func TestAnalysis_isPush(t *testing.T) {
+	tests := []struct {
+		RequestNumber int
+		CommitFrom    string
+		CommitTo      string
+		IsPush        bool
+	}{
+		{10, "", "", false},
+		{0, "aaa", "bbb", true},
+	}
+
+	for _, test := range tests {
+		analysis := NewAnalysis()
+		analysis.RequestNumber = test.RequestNumber
+		analysis.CommitFrom = test.CommitFrom
+		analysis.CommitTo = test.CommitTo
+
+		if have := analysis.IsPush(); have != test.IsPush {
+			t.Errorf("have: %v, want: %v test: %#v", have, test.IsPush, test)
+		}
 	}
 }

--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -209,6 +209,8 @@ func TestPushConfig(t *testing.T) {
 		repositoryID:    2,
 		statusesContext: "ci/gopherci/push",
 		statusesURL:     "https://github.com/owner/repo/status/abcdef",
+		commitFrom:      "aaaaaa",
+		commitTo:        "abcdef",
 		baseURL:         "https://github.com/owner/repo.git",
 		baseRef:         "abcdef~2",
 		headURL:         "https://github.com/owner/repo.git",
@@ -225,6 +227,7 @@ func TestPushConfig(t *testing.T) {
 			CloneURL:    github.String("https://github.com/owner/repo.git"),
 			HTMLURL:     github.String("https://github.com/owner/repo"),
 		},
+		Before:  github.String("aaaaaa"),
 		After:   github.String("abcdef"),
 		Commits: []github.PushEventCommit{{}, {}},
 	}
@@ -233,7 +236,6 @@ func TestPushConfig(t *testing.T) {
 	if have != want {
 		t.Errorf("have:\n%+v\nwant:\n%+v", have, want)
 	}
-
 }
 
 func TestPullRequestConfig(t *testing.T) {

--- a/internal/web/static/site.css
+++ b/internal/web/static/site.css
@@ -1,0 +1,52 @@
+
+/* Base Tweaks */ 
+html { background-color: #f5f5f5; }
+h1, h2 { margin-bottom: 1.2rem; }
+footer { text-align: center; background-color: #f5f5f5; padding: 40px 20px; border-top: 1px solid #e6e6e6; }
+
+/* Top Navigation / Logo */
+.top-nav {
+	background-color: #3069b3;
+	color: rgba(255, 255, 255, 0.85);
+	border-bottom: 1px solid white;
+	margin-bottom: 2rem;
+}
+.top-nav .logo { color: inherit; font-size: 26px; line-height: 1.7em; }
+.top-nav .logo .ci { font-weight: bold; }
+
+/* Analysis Summary */
+.asummary { border-left: 5px solid grey; margin-bottom: 2rem;}
+.asummary.Success { border-left-color: #5cb85c; }
+.asummary.Failure { border-left-color: #d9534f; }
+.asummary.Error { border-left-color: #f0ad4e; }
+.asummary .durations { text-align: center; }
+.asummary .duration { color: #757575; }
+.asummary .duration-cont { border-right: 1px solid #eceeef; }
+.asummary .duration-cont:last-child { border: none; }
+
+/* Analysis Hunk */
+.patch {
+	width: 100%;
+	margin: 0 auto 2rem;
+	font-family: monospace;
+	font-size: 12px;
+	border: 1px solid #d7d7d7;
+}
+.patch thead th { background-color: #f2f2f2; font-weight: bold; }
+.patch td, .patch th { padding: 7px 10px; }
+.patch .none { background-color: #fff; }
+.patch .e { background-color: floralwhite; }
+.patch .e td:nth-child(2) { text-align: right; font-weight: bold; }
+.patch .add { background-color: #eaffea; }
+.patch .remove { background-color: #ffecec; }
+.patch .m { font-weight: bold; }
+.patch .lno { text-align: right; background-color: rgba(250, 251, 252, 0.3); user-select: none; }
+.patch .range { background-color: #f3f8ff; }
+.patch tfoot tr:first-child { border-top: 1px solid #d7d7d7; }
+
+/* Analysis Tools Summary */
+.tools .name { width: 20%; }
+.tools .tool { border-left: 5px solid grey; }
+.tools .tool.tool-success { border-left-color: #5cb85c;  }
+.tools .tool.tool-warning { border-left-color: #f0ad4e;  }
+.tools .tool-warning .count { font-weight: bold; }

--- a/internal/web/templates/analysis.tmpl
+++ b/internal/web/templates/analysis.tmpl
@@ -1,68 +1,108 @@
 {{ template "header" . }}
 
 <div class="container">
-    <h1>Analysis</h1>
+    <h1>Analysis <small class="text-muted">for {{ if gt .Analysis.RequestNumber 0 }}#{{ .Analysis.RequestNumber }}{{ else }}{{ .Analysis.CommitTo}}{{ end }}</small></h1>
+
+	<div class="asummary {{ .Analysis.Status }}">
+		<table class="table">
+			<tbody>
+				<tr>
+					<th>Started</th><td>{{ .Analysis.CreatedAt }}</td>
+				</tr>
+				<tr>
+					<th>Build Status</th>
+					<td>
+						{{ if eq .Analysis.Status "Success" }}
+							<span class="badge badge-success">{{ .Analysis.Status }}</span>
+							<!-- <button type="button" class="btn btn-outline-danger btn-sm">Mark as Failure</button>-->
+						{{ else if eq .Analysis.Status "Failure" }}
+							<span class="badge badge-danger">{{ .Analysis.Status }}</span>
+							<!--<button type="button" class="btn btn-outline-success btn-sm">Mark as Success</button>-->
+						{{ else if eq .Analysis.Status "Error" }}
+							<span class="badge badge-warning">{{ .Analysis.Status }}</span>
+							<!--<button type="button" class="btn btn-outline-success btn-sm">Mark as Success</button>-->
+						{{ else }}
+							<!--<span class="badge badge-default">{{ .Analysis.Status }}</span>-->
+						{{ end }}
+
+						<small>with <b>{{ .TotalIssues }}</b> issue{{ if ne .TotalIssues 1 }}s{{ end }} found.</small>
+
+						<!--<button type="button" class="btn btn-secondary btn-sm">Rerun Analysis</button>-->
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
+		{{ with .Analysis }}
+			{{ if ne .Status "Pending" }}
+				<div class="container durations">
+					<div class="row">
+						<div class="col-sm duration-cont">
+							<h3 class="duration-header">Clone Duration</h3>
+							<p class="duration">{{ .CloneDuration }}</p>
+						</div>
+						<div class="col-sm duration-cont">
+							<h3 class="duration-header">Deps Duration</h3>
+							<p class="duration">{{ .DepsDuration }}</p>
+						</div>
+						<div class="col-sm duration-cont">
+							<h3 class="duration-header">Total Duration</h3>
+							<p class="duration">{{ .TotalDuration }}</p>
+						</div>
+					</div>
+				</div>
+			{{ end }}
+		{{ end }}
+	</div>
+
+    <h2>Issues</h2>
+	{{ if not .Files }}
+		<p class="alert alert-success" role="alert">No issues found!</p>
+	{{ end }}
 
 
-    {{ with .Analysis }}
-        <table class="table">
-            <tbody>
-                <tr>
-                    <th>Started</th><td>{{ .CreatedAt }}</td>
-                </tr>
-                <tr>
-                    <th>Status</th>
-                    <td>
-                        {{ if eq .Status "Success" }}
-                            <span class="badge badge-success">{{ .Status }}</span>
-                            <button type="button" class="btn btn-outline-danger btn-sm">Mark as Failure</button>
-                        {{ else if eq .Status "Failure" }}
-                            <span class="badge badge-danger">{{ .Status }}</span>
-                            <button type="button" class="btn btn-outline-success btn-sm">Mark as Success</button>
-                        {{ else if eq .Status "Error" }}
-                            <span class="badge badge-warning">{{ .Status }}</span>
-                            <button type="button" class="btn btn-outline-success btn-sm">Mark as Success</button>
-                        {{ else }}
-                            <span class="badge badge-default">{{ .Status }}</span>
-                        {{ end }}
+    {{ range .Files }}
+	<table class="patch">
+        <thead>
+            <tr><th></th><th>{{ .Path }}</th></tr>
+        </thead>
+		<tbody>
+            {{ range .Hunks }}
+                <tr><td class="range"></td><td class="range"> {{ .Range }}</td></tr>
 
-                        <button type="button" class="btn btn-secondary btn-sm">Rerun Analysis</button>
-                    </td>
-                </tr>
-                {{ if ne .Status "Pending" }}
-                    <tr>
-                        <th>Clone Duration</th><td>{{ .CloneDuration }}</td>
+                {{ range .Lines }}
+                    <tr class="{{ .ChangeType }}">
+                        <td class="lno">{{ .LineNo }}</td>
+                        <td>{{ .Line }}</td>
                     </tr>
-                    <tr>
-                        <th>Deps Duration</th><td>{{ .DepsDuration }}</td>
-                    </tr>
-                    <tr>
-                        <th>Total Duration</th><td>{{ .TotalDuration }}</td>
-                    </tr>
-                {{ end }}
-            </tbody>
-        </table>
-
-
-
-        <div class="section">
-            {{ range .Tools }}
-                <h3><a href="{{.Tool.URL}}">{{ .Tool.Name }}</a></h3>
-                <p>Found {{ len .Issues }} issues in {{ .Duration }}.</p>
-                {{ if .Issues }}
-                    <table class="table">
-                        <tbody>
-                            {{ range .Issues }}
-                                <tr><td>{{ .Path }}:{{ .Line }} {{ .Issue }}</td></tr>
-                            {{ end }}
-                        </tbody>
-                    </table>
+                    {{ range .Issues }}
+                        <tr class="e">
+                            <td class="lno"></td>
+                            <td>{{ . }}</td>
+                        </tr>
+                    {{ end }}
                 {{ end }}
             {{ end }}
-        </div>
+		</tbody>
+	</table>
     {{ end }}
-</div>
-<hr>
 
+    <h2>Tools</h2>
+    <table class="table tools">
+        <thead>
+            <tr>
+                <th class="name">Tool</th><th class="summary">Summary</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{ range .Analysis.Tools }}
+                <tr class="tool tool-{{if eq (len .Issues) 0 }}success{{ else }}warning{{ end }}">
+                    <th class="name"><a href="{{.Tool.URL}}">{{ .Tool.Name }}</a></th>
+                    <td class="summary">Found <span class="count">{{ len .Issues }}</span> issue{{ if ne (len .Issues) 1 }}s{{ end }} in <span class="timing">{{ .Duration }}</span>.</td>
+                </tr>
+            {{ end }}
+        </tbody>
+    </table>
 </div>
+
 {{ template "footer" . }}

--- a/internal/web/templates/footer.tmpl
+++ b/internal/web/templates/footer.tmpl
@@ -2,7 +2,8 @@
 <footer class="footer">
     <div class="container">
         <div class="content has-text-centered">
-            <p><a href="https://github.com/bradleyfalzon/gopherci">GitHub</a></p>
+            <p>© Bradley Falzon 2017 - <a href="https://github.com/bradleyfalzon/gopherci">GitHub</a>.</p>
+            <p>Thanks to the tool authors, the Go team and library authors I import.</p>
         </div>
     </div>
 </footer>

--- a/internal/web/templates/header.tmpl
+++ b/internal/web/templates/header.tmpl
@@ -9,5 +9,9 @@
         <title>{{ if .Title }}{{ .Title }} - {{ end }}GopherCI</title>
     </head>
     <body>
+        <header class="top-nav">
+            <div class="container">
+                <a class="logo" href="/">Gopher<span class="ci">CI</span></a>
+            </div>
+        </header>
 {{end}}
-

--- a/internal/web/vcsviewer.go
+++ b/internal/web/vcsviewer.go
@@ -1,0 +1,147 @@
+package web
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"sourcegraph.com/sourcegraph/go-diff/diff"
+
+	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/bradleyfalzon/gopherci/internal/github"
+	"github.com/pkg/errors"
+)
+
+// A VCSReader reads information about a completed analysis.
+type VCSReader interface {
+	// Diff returns a multi file unified diff as a io.ReadCloser, or an error.
+	Diff(ctx context.Context, repositoryID int, commitFrom string, commitTo string, requestNumber int) (io.ReadCloser, error)
+}
+
+// NewVCS returns a VCSReader for a given analysis.
+func NewVCS(github *github.GitHub, analysis *db.Analysis) (VCSReader, error) {
+	switch {
+	case analysis.InstallationID != 0:
+		// GitHub VCS
+		return github.NewInstallation(analysis.InstallationID)
+	default:
+		// Unknown VCS
+		return nil, errors.New("error determining VCS")
+	}
+}
+
+// A Patch represents a single file's patch.
+type Patch struct {
+	Path  string
+	Hunks []Hunk
+}
+
+// A Hunk represents a single hunk of changed lines.
+type Hunk struct {
+	Range string
+	Lines []Line
+}
+
+// ChangeType is type of change that affects a line, such as added or removed.
+type ChangeType string
+
+const (
+	// ChangeAdd means a line was added.
+	ChangeAdd ChangeType = "add"
+	// ChangeRemove means a line was removed.
+	ChangeRemove ChangeType = "remove"
+	// ChangeNone means a line was unchanged.
+	ChangeNone ChangeType = "none"
+)
+
+// A Line represents a single line in a diff.
+type Line struct {
+	Line       string
+	ChangeType ChangeType
+	LineNo     int
+	Issues     []string
+}
+
+// DiffIssues reads a diff and adds the issues to the lines affected. Only
+// hunks with issues will be returned.
+func DiffIssues(ctx context.Context, diffReader io.Reader, issues []db.Issue) ([]Patch, error) {
+	ghDiff, err := ioutil.ReadAll(&io.LimitedReader{R: diffReader, N: 1e9})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read from diff reader")
+	}
+
+	fileDiffs, err := diff.ParseMultiFileDiff(ghDiff)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse diff")
+	}
+
+	var patches []Patch
+	for _, fileDiff := range fileDiffs {
+		file := Patch{
+			Path: fileDiff.NewName[2:], // strip leading "a/" or "b/"
+		}
+
+		var fileHasIssues bool
+		for _, fileHunk := range fileDiff.Hunks {
+			scanner := bufio.NewScanner(bytes.NewReader(fileHunk.Body))
+
+			hunk := Hunk{
+				Range: fmt.Sprintf("@@ -%d,%d +%d,%d @@", fileHunk.OrigStartLine, fileHunk.OrigLines, fileHunk.NewStartLine, fileHunk.NewLines),
+			}
+
+			var hunkHasIssues bool
+			for diffLineNo := int(fileHunk.NewStartLine); scanner.Scan(); diffLineNo++ {
+				if len(scanner.Text()) == 0 {
+					return nil, fmt.Errorf("file: %q, hunk: %q body contains empty line", file.Path, hunk.Range)
+				}
+
+				var changeType = ChangeNone
+				switch scanner.Text()[0] {
+				case byte('+'):
+					changeType = ChangeAdd
+				case byte('-'):
+					changeType = ChangeRemove
+				}
+
+				// Find issues matching this line, ignore removed lines as an
+				// issue may appear on the same line number that replaced this.
+				var lineIssues []string
+				if changeType != ChangeRemove {
+					for _, issue := range issues {
+						if issue.Path == file.Path && issue.Line == diffLineNo {
+							hunkHasIssues = true
+							lineIssues = append(lineIssues, issue.Issue)
+						}
+					}
+				}
+
+				hunk.Lines = append(hunk.Lines, Line{
+					ChangeType: changeType,
+					LineNo:     diffLineNo,
+					Line:       scanner.Text()[1:],
+					Issues:     lineIssues,
+				})
+
+				if changeType == ChangeRemove {
+					diffLineNo--
+				}
+			}
+			if scanner.Err() != nil {
+				return nil, errors.Wrapf(err, "errors scanning file %v", file.Path)
+			}
+
+			if hunkHasIssues {
+				fileHasIssues = true
+				file.Hunks = append(file.Hunks, hunk)
+			}
+		}
+
+		if fileHasIssues {
+			patches = append(patches, file)
+		}
+	}
+	return patches, nil
+}

--- a/internal/web/vcsviewer_test.go
+++ b/internal/web/vcsviewer_test.go
@@ -1,0 +1,65 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/bradleyfalzon/gopherci/internal/db"
+)
+
+func TestAnalysisFiles(t *testing.T) {
+	diffReader := bytes.NewBuffer([]byte(`diff --git a/main.go b/main.go
+index 4810940..4090359 100644
+--- a/main.go
++++ b/main.go
+@@ -3,5 +3,5 @@ package main
+ import "fmt"
+ 
+ func main() {
+-       fmt.Println("Hi")
++       fmt.Println("Hi: %v", "alice")
+ }
+diff --git a/noissues.go b/noissues.go
+new file mode 100644
+index 0000000..3de84a3
+--- /dev/null
++++ b/noissues.go
+@@ -0,0 +1,3 @@
++package main
++
++func foo() {}
+`))
+
+	// TODO give it more issues
+	issues := []db.Issue{
+		{Path: "main.go", Line: 6, Issue: "issue here"},
+	}
+
+	havePatches, err := DiffIssues(context.Background(), diffReader, issues)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantPatches := []Patch{{
+		Path: "main.go",
+		Hunks: []Hunk{
+			{
+				Range: "@@ -3,5 +3,5 @@",
+				Lines: []Line{
+					{Line: "import \"fmt\"", ChangeType: "none", LineNo: 3, Issues: nil},
+					{Line: "", ChangeType: "none", LineNo: 4, Issues: nil},
+					{Line: "func main() {", ChangeType: "none", LineNo: 5, Issues: nil},
+					{Line: "       fmt.Println(\"Hi\")", ChangeType: "remove", LineNo: 6, Issues: nil},
+					{Line: "       fmt.Println(\"Hi: %v\", \"alice\")", ChangeType: "add", LineNo: 6, Issues: []string{"issue here"}},
+					{Line: "}", ChangeType: "none", LineNo: 7, Issues: nil},
+				},
+			},
+		},
+	}}
+
+	if !reflect.DeepEqual(havePatches, wantPatches) {
+		t.Errorf("\nhave: %#v\nwant: %#v", havePatches, wantPatches)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func main() {
 	}
 
 	// Web routes
-	web, err := web.NewWeb(db)
+	web, err := web.NewWeb(db, gh)
 	if err != nil {
 		log.Fatalln("main: error loading web:", err)
 	}

--- a/migrations/5_analysis_extra_fields.sql
+++ b/migrations/5_analysis_extra_fields.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+
+-- commit_from and commit_to is before/after or from/to for GitHub or GitLab respectively
+ALTER TABLE analysis ADD COLUMN commit_from VARCHAR(128) NULL DEFAULT NULL AFTER repository_id;
+ALTER TABLE analysis ADD COLUMN commit_to VARCHAR(128) NULL DEFAULT NULL AFTER commit_from;
+
+-- request number is pull request number or merge request number for GitHub or GitLan respectively
+ALTER TABLE analysis ADD COLUMN request_number INT UNSIGNED NULL DEFAULT NULL AFTER commit_to;
+
+-- +migrate Down
+ALTER TABLE analysis DROP COLUMN commit_from, DROP COLUMN commit_to, DROP COLUMN request_number;
+
+


### PR DESCRIPTION
We'll do this by storing before and after commits and pr number in
the analysis table. They'll be used for display, but also to generate API
endpoints instead of storing the actual API URLs.

https://api.github.com/repositories/{repository_id}/pulls/{request_number}
https://api.github.com/repositories/{repository_id}/compare/{commit_from}...{commit_after}

GitLab has similar URLs which only requires merge request number or from
and to SHAs.

We've also created a new interface called VCSViewer, this will be used
to abstract away the VCS, such as GitHub, GitLab and others, providing
a uniform interface. It will likely be expanded upon in the furture to
return other information. github.Installation will now begin to implement
this interface.

The recently added package "web" currently cares for this interface, I
don't believe this will be its final resting place, web has no business
handling this interface when it's likely we'll add an email package at
some stage in the future. So something will be moved or renamed, I just
don't know what.

![screenshot 2017-04-05 20 08 20](https://cloud.githubusercontent.com/assets/1834577/24701939/abf20f00-1a3b-11e7-9483-595d257761ce.png)
