### PR TITLE
Add 3 issues for staticcheck, golint and unused (to then be reverted)

### DIFF
--- a/internal/analyser/analyser.go
+++ b/internal/analyser/analyser.go
@@ -92,6 +92,9 @@ func Analyse(ctx context.Context, analyser Analyser, tools []db.Tool, config Con
 		return errors.Wrap(err, "analyser could create new executer")
 	}
 
+	if err != nil {
+	}
+
 	var (
 		// baseRef is the reference to the base branch or before commit, the ref
 		// of the state before this PR/Push.
@@ -237,3 +240,5 @@ func Analyse(ctx context.Context, analyser Analyser, tools []db.Tool, config Con
 	analysis.TotalDuration = db.Duration(time.Since(start))
 	return nil
 }
+
+func ExportedNoComment() {}

--- a/internal/db/sqldb.go
+++ b/internal/db/sqldb.go
@@ -134,6 +134,13 @@ func (db *SQLDB) FinishAnalysis(analysisID int, status AnalysisStatus, analysis 
 	return nil
 }
 
+// Foo is an example of staticcheck's incredibly useful SA4006
+func (db *SQLDB) Foo() error {
+	_, err := db.sqlx.Exec("SELECT 1")
+	_, err = db.sqlx.Exec("SELECT 1")
+	return err
+}
+
 // GetAnalysis implements the DB interface.
 func (db *SQLDB) GetAnalysis(analysisID int) (*Analysis, error) {
 	analysis := NewAnalysis()

--- a/internal/github/installation.go
+++ b/internal/github/installation.go
@@ -23,6 +23,9 @@ type Installation struct {
 	client *github.Client
 }
 
+func unused() {
+}
+
 func (g *GitHub) NewInstallation(installationID int) (*Installation, error) {
 
 	// TODO reuse installations, so we maintain rate limit state between webhooks


### PR DESCRIPTION
GopherCI needs some example analysis o be used in URL monitoring as well
as general examples. Using a third party repo (such as the one in the
integration tests repo) risks the reports failing when the diffs are
no longer available.

For this reason, I thought it might just be best for this repo to
have the examples, as this should always exist (GopherCI handles
repositories being renamed) and there won't be any force pushes.

This commit will then be reverted.