### PR TITLE
Handle repositories with no history (eg new)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -327,3 +327,17 @@ func TestAnalysisView(t *testing.T) {
 
 	want200OK(t, *status.TargetURL)
 }
+
+// TestMissingBeforeBranch tests the case where the before ref does not exist,
+// such as branch tracking different tree or new repository.
+func TestMissingBeforeRef(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	it := NewIntegrationTest(ctx, t)
+	defer it.Close()
+
+	it.Exec("new-go-repository.sh", "master")
+
+	it.WaitForSuccess("master", "ci/gopherci/push")
+}

--- a/testdata/new-go-repository.sh
+++ b/testdata/new-go-repository.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eux
+
+# Expects only previous commit
+
+git checkout $1
+
+cp .git/config config
+rm -rf .git
+git init
+mv config .git/
+
+cat > foo.go <<EOF
+package foo
+func Foo() {}  // expect golint exported without comment
+EOF
+
+git add .
+git commit -m "commit"
+
+git push -f -u origin $1


### PR DESCRIPTION
For a new repository, or a branch which doesn't have any history
(tracking a different git tree), we can't get a diff using the
"git diff abcd~5...abcd" method.

Instead, we'll try that way, and if it fails, try to get the diff
using "git show abcd".

I chose not to have the analyser check the ref "abcd~5" exists first
to help simplify the code, with less conditionals, but I'm not
convinced this is any more readable and potentially less reliable.
Therefore, it may be refactored in the future.

I've added an integration test for this as well, to ensure the
behaviour with git is always tested and not mocked like it is in the
unit test.

Fixes #79.