### PR TITLE
Ignore GitHub events early, such as no Go repos and no installation

### DIFF
--- a/internal/analyser/analyser.go
+++ b/internal/analyser/analyser.go
@@ -84,7 +84,7 @@ const (
 
 // Analyse downloads a repository set in config in an environment provided by
 // analyser, running the series of tools. Writes results to provided analysis,
-// or an error.
+// or an error. The repository is expected to contain at least one Go package.
 func Analyse(ctx context.Context, analyser Analyser, tools []db.Tool, config Config, analysis *db.Analysis) error {
 	// Get a new executer/environment to execute in
 	exec, err := analyser.NewExecuter(ctx, config.GoSrcPath)

--- a/internal/github/installation.go
+++ b/internal/github/installation.go
@@ -52,6 +52,11 @@ func (g *GitHub) NewInstallation(installationID int) (*Installation, error) {
 	return &Installation{ID: installation.ID, client: client}, nil
 }
 
+// IsEnabled returns true if an installation is enabled.
+func (i *Installation) IsEnabled() bool {
+	return i != nil
+}
+
 // StatusState is the state of a GitHub Status API as defined in
 // https://developer.github.com/v3/repos/statuses/
 type StatusState string

--- a/internal/github/installation_test.go
+++ b/internal/github/installation_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/google/go-github/github"
 )
 
+func TestInstallation_isEnabled(t *testing.T) {
+	var i *Installation
+	if want := false; i.IsEnabled() != want {
+		t.Errorf("want: %v, have: %v", want, i.IsEnabled())
+	}
+	i = &Installation{}
+	if want := true; i.IsEnabled() != want {
+		t.Errorf("want: %v, have: %v", want, i.IsEnabled())
+	}
+}
+
 func TestFilterIssues_maxIssueComments(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer ts.Close()


### PR DESCRIPTION
This commit sets up a better framework for ignoring certain GitHub
events early, before they're sent to the queue.

We don't queue them because some organisations have many non-Go
repositories and queuing all those jobs to just be immediately
discarded was becoming a little wasteful. In the future, I'm happy
for this decision to be reversed.

This is implemented in a GitHub specific manner, as it ensured the
events would be discarded before a clone of the repository occurred.

Resolves #80.
Related to #73.

Related video: https://youtu.be/fjPJDC-0hXA