### PR TITLE
Add .gopherci.yml support and use it to install APT packages for CGO.

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -341,3 +341,16 @@ func TestMissingBeforeRef(t *testing.T) {
 
 	it.WaitForSuccess("master", "ci/gopherci/push")
 }
+
+// TestAPTPackagesCGO tests that cgo dependencies are installed via apt-get.
+func TestAPTPackagesCGO(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	it := NewIntegrationTest(ctx, t)
+	defer it.Close()
+
+	it.Exec("apt-cgo.sh", "aptcgo")
+
+	it.WaitForSuccess("aptcgo", "ci/gopherci/push")
+}

--- a/internal/analyser/configReader.go
+++ b/internal/analyser/configReader.go
@@ -11,7 +11,8 @@ import (
 
 // RepoConfig contains the analyser configuration for the repository.
 type RepoConfig struct {
-	Tools []db.Tool
+	APTPackages []string `yaml:"apt_packages"`
+	Tools       []db.Tool
 }
 
 // A ConfigReader returns a repository's configuration.

--- a/internal/analyser/configReader.go
+++ b/internal/analyser/configReader.go
@@ -1,0 +1,53 @@
+package analyser
+
+import (
+	"context"
+
+	yaml "gopkg.in/yaml.v1"
+
+	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/pkg/errors"
+)
+
+// RepoConfig contains the analyser configuration for the repository.
+type RepoConfig struct {
+	Tools []db.Tool
+}
+
+// A ConfigReader returns a repository's configuration.
+type ConfigReader interface {
+	Read(context.Context, Executer) (RepoConfig, error)
+}
+
+// YAMLConfig implements a ConfigReader by reading a yaml configuration file
+// from the repositories root.
+type YAMLConfig struct {
+	Tools []db.Tool // Preset tools to use, before per repo config has been applied
+}
+
+var _ ConfigReader = &YAMLConfig{}
+
+// Read implements the ConfigReader interface.
+func (c *YAMLConfig) Read(ctx context.Context, exec Executer) (RepoConfig, error) {
+	cfg := RepoConfig{
+		Tools: c.Tools,
+	}
+
+	const configFilename = ".gopherci.yml"
+
+	args := []string{"cat", configFilename}
+	yml, err := exec.Execute(ctx, args)
+	switch err.(type) {
+	case nil:
+	case *NonZeroError:
+		return cfg, nil
+	default:
+		return cfg, errors.Wrapf(err, "could not read %s", configFilename)
+	}
+
+	if err = yaml.Unmarshal(yml, &cfg); err != nil {
+		return cfg, errors.Wrapf(err, "could not unmarshal %s", configFilename)
+	}
+
+	return cfg, nil
+}

--- a/internal/analyser/configReader_test.go
+++ b/internal/analyser/configReader_test.go
@@ -1,0 +1,80 @@
+package analyser
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/bradleyfalzon/gopherci/internal/db"
+)
+
+func TestYAMLConfig_default(t *testing.T) {
+	exec := &mockAnalyser{
+		ExecuteOut: [][]byte{{}},
+		ExecuteErr: []error{&NonZeroError{ExitCode: 1}},
+	}
+
+	reader := &YAMLConfig{
+		Tools: []db.Tool{{Name: "tool1"}},
+	}
+	have, err := reader.Read(context.Background(), exec)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	want := RepoConfig{Tools: reader.Tools}
+
+	if !reflect.DeepEqual(have, want) {
+		t.Errorf("\nhave: %v\nwant: %v", have, want)
+	}
+}
+
+func TestYAMLConfig_unknownError(t *testing.T) {
+	exec := &mockAnalyser{
+		ExecuteOut: [][]byte{{}},
+		ExecuteErr: []error{errors.New("unknown error")},
+	}
+
+	reader := &YAMLConfig{}
+	_, err := reader.Read(context.Background(), exec)
+	if err == nil {
+		t.Errorf("expected error, have: %v", err)
+	}
+}
+
+func TestYAMLConfig_unmarshalError(t *testing.T) {
+	contents := []byte("\t")
+	exec := &mockAnalyser{
+		ExecuteOut: [][]byte{contents},
+		ExecuteErr: []error{nil},
+	}
+
+	reader := &YAMLConfig{}
+	_, err := reader.Read(context.Background(), exec)
+	if err == nil {
+		t.Errorf("expected error, have: %v", err)
+	}
+}
+
+func TestYAMLConfig(t *testing.T) {
+	contents := []byte(`# .gopherci.yml config`)
+	exec := &mockAnalyser{
+		ExecuteOut: [][]byte{contents},
+		ExecuteErr: []error{nil},
+	}
+
+	reader := &YAMLConfig{
+		Tools: []db.Tool{{Name: "tool1"}},
+	}
+	have, err := reader.Read(context.Background(), exec)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	want := RepoConfig{Tools: reader.Tools}
+
+	if !reflect.DeepEqual(have, want) {
+		t.Errorf("\nhave: %v\nwant: %v", have, want)
+	}
+}

--- a/internal/analyser/configReader_test.go
+++ b/internal/analyser/configReader_test.go
@@ -58,7 +58,10 @@ func TestYAMLConfig_unmarshalError(t *testing.T) {
 }
 
 func TestYAMLConfig(t *testing.T) {
-	contents := []byte(`# .gopherci.yml config`)
+	contents := []byte(`# .gopherci.yml config
+apt_packages:
+    - package1
+`)
 	exec := &mockAnalyser{
 		ExecuteOut: [][]byte{contents},
 		ExecuteErr: []error{nil},
@@ -72,7 +75,10 @@ func TestYAMLConfig(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want := RepoConfig{Tools: reader.Tools}
+	want := RepoConfig{
+		APTPackages: []string{"package1"},
+		Tools:       reader.Tools,
+	}
 
 	if !reflect.DeepEqual(have, want) {
 		t.Errorf("\nhave: %v\nwant: %v", have, want)

--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -372,7 +372,11 @@ func (g *GitHub) Analyse(cfg AnalyseConfig) (err error) {
 		GoSrcPath: cfg.goSrcPath,
 	}
 
-	err = analyser.Analyse(ctx, g.analyser, cfg.cloner, tools, acfg, analysis)
+	configReader := &analyser.YAMLConfig{
+		Tools: tools,
+	}
+
+	err = analyser.Analyse(ctx, g.analyser, cfg.cloner, configReader, acfg, analysis)
 	if err != nil {
 		return errors.Wrap(err, "could not run analyser")
 	}

--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -162,6 +162,8 @@ func checkPRAction(e *github.PullRequestEvent) error {
 	return nil
 }
 
+const configFilename = ".gopherci.yml"
+
 // checkPRAffectsGo returns true if a pull request modifies, adds or removes
 // Go files, else returns error if an error occurs.
 func checkPRAffectsGo(ctx context.Context, installation *Installation, owner, repo string, number int) (bool, error) {
@@ -172,7 +174,7 @@ func checkPRAffectsGo(ctx context.Context, installation *Installation, owner, re
 			return false, errors.Wrap(err, "could not list files")
 		}
 		for _, file := range files {
-			if hasGoExtension(*file.Filename) {
+			if hasGoExtension(*file.Filename) || *file.Filename == configFilename {
 				return true, nil
 			}
 		}
@@ -188,7 +190,7 @@ func checkPRAffectsGo(ctx context.Context, installation *Installation, owner, re
 func checkPushAffectsGo(event *github.PushEvent) bool {
 	hasGoFile := func(files []string) bool {
 		for _, filename := range files {
-			if hasGoExtension(filename) {
+			if hasGoExtension(filename) || filename == configFilename {
 				return true
 			}
 		}

--- a/testdata/apt-cgo.sh
+++ b/testdata/apt-cgo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eux
+
+git checkout -b $1
+
+mkdir cgo
+cat > cgo/main.go <<EOF
+package main
+
+/*
+#include <gsl/gsl_version.h>
+
+const char* ver() {
+        return GSL_VERSION;
+    }
+*/
+import "C"
+
+func main() {
+        println(C.GoString(C.ver()))
+}
+EOF
+
+cat > .gopherci.yml <<EOF
+apt_packages:
+    - libgsl0-dev
+EOF
+
+git add .
+git commit -m "commit"
+git push -f -u origin HEAD


### PR DESCRIPTION
Broken into 3 commits:

```
Users should be able to apply per repository configuration for GopherCI via
a config file in the repository, this allows non-admin users to modify
GopherCI on a per repository basis if they have write access. Which practically
means users can also have their pull request modify GopherCI if they require
additional packages to be installed (for cgo for example) or if they want to
modify the tools being run.

We achieve this by including a YAMLConfig which implements a configReader
interface, an interface was chosen primarily to keep tests simpler, but
the analyser doesn't really care where the config came from, just that it's
able to receive one.

The YAMLConfig should be preloaded with the global settings and then it should
filter the config based on reading the repository's config file, and finally
returning the config to analyser to use.
```

```
Currently GopherCI has the ability to ignore GitHub events (Push/Pull)
if they do not modify Go files. But user's might want GopherCI to run
when they're tweaking the .gopherci.yml file.
```

```
Some packages using cgo need to have their cgo dependencies installed
before other dependencies are fetched or tools ran. This change allows
users to install APT packages.

An integration test has also been added with a program that depends on a
C library that isn't installed by default.

Note, not all cgo dependencies are available via APT, so this change
doesn't address all use cases.
```

Relates #8. 
Fixes #91.