### PR TITLE
Improve error handling on Analysis page

### DIFF
--- a/internal/analyser/analyser_test.go
+++ b/internal/analyser/analyser_test.go
@@ -93,7 +93,7 @@ index 0000000..6362395
 	}
 
 	mockDB := db.NewMockDB()
-	analysis, _ := mockDB.StartAnalysis(1, 2)
+	analysis, _ := mockDB.StartAnalysis(1, 2, "commitFrom", "commitTo", 0)
 	cloner := &mockCloner{}
 	refReader := &FixedRef{BaseRef: "base-ref"}
 	configReader := &mockConfig{

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -19,8 +19,10 @@ type DB interface {
 	// ListTools returns all tools. Returns nil if no tools were found, error will
 	// be non-nil if an error occurs.
 	ListTools() ([]Tool, error)
-	// StartAnalysis records a new analysis.
-	StartAnalysis(ghInstallationID, repositoryID int) (*Analysis, error)
+	// StartAnalysis records a new analysis. RequestNumber is a GitHub Pull Request
+	// ID (or Merge Request) and may be 0 for none, if 0 commitFrom and commitTo
+	// must be set.
+	StartAnalysis(ghInstallationID, repositoryID int, commitFrom, commitTo string, requestNumber int) (*Analysis, error)
 	// FinishAnalysis marks a status as finished.
 	FinishAnalysis(analysisID int, status AnalysisStatus, analysis *Analysis) error
 	// GetAnalysis returns an analysis for a given analysisID, returns nil if no

--- a/internal/db/mockdb.go
+++ b/internal/db/mockdb.go
@@ -63,9 +63,12 @@ func (db *MockDB) ListTools() ([]Tool, error) {
 }
 
 // StartAnalysis implements the DB interface.
-func (db *MockDB) StartAnalysis(ghInstallationID, repositoryID int) (*Analysis, error) {
+func (db *MockDB) StartAnalysis(ghInstallationID, repositoryID int, commitFrom, commitTo string, requestNumber int) (*Analysis, error) {
 	analysis := NewAnalysis()
 	analysis.ID = 99
+	analysis.CommitFrom = commitFrom
+	analysis.CommitTo = commitTo
+	analysis.RequestNumber = requestNumber
 	return analysis, nil
 }
 

--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -328,16 +328,12 @@ func (g *GitHub) Analyse(cfg AnalyseConfig) (err error) {
 	}
 
 	// Record start of analysis
-	analysis, err := g.db.StartAnalysis(install.ID, cfg.repositoryID)
+	analysis, err := g.db.StartAnalysis(install.ID, cfg.repositoryID, cfg.commitFrom, cfg.commitTo, cfg.pr)
 	if err != nil {
 		return errors.Wrap(err, "error starting analysis")
 	}
 	log.Println("analysisID:", analysis.ID)
 	analysisURL := analysis.HTMLURL(g.gciBaseURL)
-
-	analysis.CommitFrom = cfg.commitFrom
-	analysis.CommitTo = cfg.commitTo
-	analysis.RequestNumber = cfg.pr
 
 	// Set the CI status API to pending
 	err = install.SetStatus(ctx, cfg.statusesContext, cfg.statusesURL, StatusStatePending, "In progress", analysisURL)

--- a/internal/web/templates/analysis.tmpl
+++ b/internal/web/templates/analysis.tmpl
@@ -75,38 +75,37 @@
 	</div>
 </div>
 
-<div class="container issues-cont">
-    <h2>Issues</h2>
-	{{ if not .Patches }}
-		<p class="alert alert-success" role="alert">No issues found!</p>
-	{{ end }}
+<!-- Patches may not be set because of an error getting diffs, or there were no issues -->
+{{ if .Patches }}
+    <div class="container issues-cont">
+        <h2>Issues</h2>
 
-    {{ range .Patches }}
-	<table class="patch">
-        <thead>
-            <tr><th></th><th>{{ .Path }}</th></tr>
-        </thead>
-		<tbody>
-            {{ range .Hunks }}
-                <tr><td class="range"></td><td class="range"> {{ .Range }}</td></tr>
+        {{ range .Patches }}
+        <table class="patch">
+            <thead>
+                <tr><th></th><th>{{ .Path }}</th></tr>
+            </thead>
+            <tbody>
+                {{ range .Hunks }}
+                    <tr><td class="range"></td><td class="range"> {{ .Range }}</td></tr>
 
-                {{ range .Lines }}
-                    <tr class="{{ .ChangeType }}">
-                        <td class="lno">{{ .LineNo }}</td>
-                        <td>{{ .Line }}</td>
-                    </tr>
-                    {{ range .Issues }}
-                        <tr id="issue-{{ .ID }}" class="e">
-                            <td class="lno"></td>
-                            <td>{{ .Issue }}</td>
+                    {{ range .Lines }}
+                        <tr class="{{ .ChangeType }}">
+                            <td class="lno">{{ .LineNo }}</td>
+                            <td>{{ .Line }}</td>
                         </tr>
+                        {{ range .Issues }}
+                            <tr id="issue-{{ .ID }}" class="e">
+                                <td class="lno"></td>
+                                <td>{{ .Issue }}</td>
+                            </tr>
+                        {{ end }}
                     {{ end }}
                 {{ end }}
-            {{ end }}
-		</tbody>
-	</table>
-    {{ end }}
-
-</div>
+            </tbody>
+        </table>
+        {{ end }}
+    </div>
+{{ end }}
 
 {{ template "footer" . }}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -91,19 +91,19 @@ func (web *Web) AnalysisHandler(w http.ResponseWriter, r *http.Request) {
 	// push?), if so, we should just give the template the issues to render.
 	// If no errors, give template nil issues.
 
+	var patches []Patch
 	diffReader, err := vcs.Diff(r.Context(), analysis.RepositoryID, analysis.CommitFrom, analysis.CommitTo, analysis.RequestNumber)
 	if err != nil {
 		log.Printf("error getting diff from VCS for analysisID %v: %v", analysisID, err)
-		web.errorHandler(w, r, http.StatusInternalServerError, "Could not get VCS")
-		return
-	}
-	defer diffReader.Close()
+	} else {
+		defer diffReader.Close()
 
-	patches, err := DiffIssues(r.Context(), diffReader, analysis.Issues())
-	if err != nil {
-		log.Printf("error reading vcs with analysisID %v: %v", analysisID, err)
-		web.errorHandler(w, r, http.StatusInternalServerError, "Could not read VCS")
-		return
+		patches, err = DiffIssues(r.Context(), diffReader, analysis.Issues())
+		if err != nil {
+			log.Printf("error reading vcs with analysisID %v: %v", analysisID, err)
+			web.errorHandler(w, r, http.StatusInternalServerError, "Could not read VCS")
+			return
+		}
 	}
 
 	var page = struct {


### PR DESCRIPTION
DB StartAnalysis should take commitFrom, commitTo, and requestNumber:

```
Previously these fields were only added after a successful analysis.
This change makes those three required fields a part of the constructor
so no matter what failure scenario there is, those fields are still set.

The other option is to ensure a failed analysis still sets some of
these fields, but there may be some scenarios where those fields may
have been missed, such as a panic.
```

Analysis page fetching diff should not be a critical error:

```
The db.Analysis type contains a list of the issues per tool that were
stored in the database. We use these in two ways:

A) Provide it to web.DiffIssues function to combine a diff/patch with
the issue to show the issue inline.

B) Show a summary of the issues, grouped by tool.

If fetching the diff/patch fails, we can still show the issues per
tool, this contains all the information a user really requires.

Now, patches is only set in the template if there were issues *and*
there was no errors fetching the diff.
```

Relates to #88.