### PR TITLE
Upgrade chi router from v2 to v3

### DIFF
--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/bradleyfalzon/gopherci/internal/db"
 	"github.com/bradleyfalzon/gopherci/internal/github"
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 )
 
 // Web handles general web/html responses (not API hooks).


### PR DESCRIPTION
We use github.com/go-chi/chi to make routing easier with parameters
in URLs, chaining multiple middleware and enforcing HTTP methods to
certain routes.

chi recently changed their import path during the v2 to v3 upgrade
from github.com/pressly/chi to github.com/go-chi/chi, removed
(although the change log states deprecated) the file server helper
and changed the URL parameters placeholders from `/:id` to `/{id}`.

This change updates the import path, implements our own file server
helper (based on their example), and updates the URL parameters
placeholder.