### PR TITLE
Limit virtual memory for linters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ DB_PASSWORD=
 # filesystem analyser required, see https://github.com/gopherci/gopherci-env
 ANALYSER=docker
 
+# Limit the maximum memory usage of commands executing during an analysis
+# Values are in MiB. If this value is too small, some commands may fail with
+# unexpected error messages.
+#ANALYSER_MEMORY_LIMIT=
+
 # Path for the File System Analyser, this should be a separate GOPATH
 # compatible structure just for CI purposes.
 # Required if ANALYSER=filesystem

--- a/internal/analyser/docker_test.go
+++ b/internal/analyser/docker_test.go
@@ -2,13 +2,15 @@ package analyser
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"testing"
 )
 
 func TestDocker(t *testing.T) {
-	docker, err := NewDocker(DockerDefaultImage)
+	memLimit := 512
+	docker, err := NewDocker(DockerDefaultImage, memLimit)
 	if err != nil {
 		t.Fatalf("unexpected error initialising docker: %v", err)
 	}
@@ -26,6 +28,15 @@ func TestDocker(t *testing.T) {
 
 	// Ensure current working directory is project path
 	if want := "/go/src/github.com/gopherci/gopherci\n"; want != string(out) {
+		t.Errorf("\nwant %q\nhave %q", want, out)
+	}
+
+	// Ensure correct memory limit
+	out, err = exec.Execute(ctx, []string{"ulimit", "-v"})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if want := fmt.Sprintf("%d\n", memLimit*1024); want != string(out) {
 		t.Errorf("\nwant %q\nhave %q", want, out)
 	}
 

--- a/internal/analyser/filesystem.go
+++ b/internal/analyser/filesystem.go
@@ -22,16 +22,18 @@ import (
 // FileSystem is safe to use concurrently, as all directories are created
 // with random file names.
 type FileSystem struct {
-	base string // base is the base dir all projects have in common
+	base     string // base is the base dir all projects have in common
+	memLimit int    // virtual memory limit in MiB for processes
 }
 
 // Ensure FileSystem implements Analyser
 var _ Analyser = (*FileSystem)(nil)
 
 // NewFileSystem returns an FileSystem which uses the path base to build
-// contained environments on the file system.
-func NewFileSystem(base string) (*FileSystem, error) {
-	fs := &FileSystem{base: base}
+// contained environments on the file system. If memLimit is > 0, limit the
+// amount of memory (MiB) a process can use.
+func NewFileSystem(base string, memLimit int) (*FileSystem, error) {
+	fs := &FileSystem{base: base, memLimit: memLimit}
 	if err := unix.Access(base, unix.W_OK); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("%q is not writable", base))
 	}
@@ -40,7 +42,7 @@ func NewFileSystem(base string) (*FileSystem, error) {
 
 // NewExecuter implements the Analyser interface
 func (fs *FileSystem) NewExecuter(_ context.Context, goSrcPath string) (Executer, error) {
-	e := &FileSystemExecuter{}
+	e := &FileSystemExecuter{memLimit: fs.memLimit}
 	if err := e.mktemp(fs.base, goSrcPath); err != nil {
 		return nil, err
 	}
@@ -52,6 +54,7 @@ func (fs *FileSystem) NewExecuter(_ context.Context, goSrcPath string) (Executer
 type FileSystemExecuter struct {
 	gopath   string // gopath is base/$rand
 	projpath string // projpath is gopath/src/<goSrcPath>
+	memLimit int    // virtual memory limit in MiB for processes
 }
 
 // Ensure FileSystemExecuter implements Executer
@@ -71,6 +74,7 @@ func (e *FileSystemExecuter) mktemp(base, goSrcPath string) error {
 // Execute implements the Executer interface
 func (e *FileSystemExecuter) Execute(ctx context.Context, args []string) ([]byte, error) {
 	cmds := []string{
+		fmt.Sprintf("ulimit -v %d", e.memLimit*1024),
 		strings.Join(args, " "),
 	}
 	args = []string{"bash", "-c", strings.Join(cmds, " && ")}

--- a/internal/analyser/filesystem.go
+++ b/internal/analyser/filesystem.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -69,7 +70,11 @@ func (e *FileSystemExecuter) mktemp(base, goSrcPath string) error {
 
 // Execute implements the Executer interface
 func (e *FileSystemExecuter) Execute(ctx context.Context, args []string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, args[0])
+	cmds := []string{
+		strings.Join(args, " "),
+	}
+	args = []string{"bash", "-c", strings.Join(cmds, " && ")}
+	cmd := exec.CommandContext(ctx, "bash")
 	cmd.Args = args
 	cmd.Dir = e.projpath
 	cmd.Env = []string{"GOPATH=" + e.gopath, "PATH=" + os.Getenv("PATH")}

--- a/internal/analyser/filesystem_test.go
+++ b/internal/analyser/filesystem_test.go
@@ -23,7 +23,7 @@ func TestFileSystem(t *testing.T) {
 
 	exec, err := fs.NewExecuter(ctx, "github.com/gopherci/gopherci")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	gopath := exec.(*FileSystemExecuter).gopath
 
@@ -31,7 +31,7 @@ func TestFileSystem(t *testing.T) {
 		t.Errorf("expected %q to exist", gopath)
 	}
 
-	out, err := exec.Execute(ctx, []string{"bash", "-c", "echo $GOPATH $PATH"})
+	out, err := exec.Execute(ctx, []string{"echo $GOPATH $PATH"})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/internal/analyser/filesystem_test.go
+++ b/internal/analyser/filesystem_test.go
@@ -2,20 +2,23 @@ package analyser
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 )
 
 func TestNewFileSystem_notExist(t *testing.T) {
+	memLimit := 512
 	base := "/does-not-exist"
-	_, err := NewFileSystem(base)
+	_, err := NewFileSystem(base, memLimit)
 	if err == nil {
 		t.Errorf("expected error for path %v, got: %v", base, err)
 	}
 }
 
 func TestFileSystem(t *testing.T) {
-	fs, err := NewFileSystem(os.TempDir())
+	memLimit := 512
+	fs, err := NewFileSystem(os.TempDir(), memLimit)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -47,6 +50,15 @@ func TestFileSystem(t *testing.T) {
 
 	// Ensure current working directory is project path
 	if want := gopath + "/src/github.com/gopherci/gopherci\n"; want != string(out) {
+		t.Errorf("\nwant %q\nhave %q", want, out)
+	}
+
+	// Ensure correct memory limit
+	out, err = exec.Execute(ctx, []string{"ulimit", "-v"})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if want := fmt.Sprintf("%d\n", memLimit*1024); want != string(out) {
 		t.Errorf("\nwant %q\nhave %q", want, out)
 	}
 

--- a/main.go
+++ b/main.go
@@ -92,6 +92,14 @@ func main() {
 		log.Fatalln("could not initialise db:", err)
 	}
 
+	var analyserMemoryLimit int64
+	if os.Getenv("ANALYSER_MEMORY_LIMIT") != "" {
+		analyserMemoryLimit, err = strconv.ParseInt(os.Getenv("ANALYSER_MEMORY_LIMIT"), 10, 32)
+		if err != nil {
+			log.Fatalln("could not parse ANALYSER_MEMORY_LIMIT:", err)
+		}
+	}
+
 	// Analyser
 	log.Printf("Using analyser %q", os.Getenv("ANALYSER"))
 	var analyse analyser.Analyser
@@ -100,7 +108,7 @@ func main() {
 		if os.Getenv("ANALYSER_FILESYSTEM_PATH") == "" {
 			log.Fatalln("ANALYSER_FILESYSTEM_PATH is not set")
 		}
-		analyse, err = analyser.NewFileSystem(os.Getenv("ANALYSER_FILESYSTEM_PATH"))
+		analyse, err = analyser.NewFileSystem(os.Getenv("ANALYSER_FILESYSTEM_PATH"), int(analyserMemoryLimit))
 		if err != nil {
 			log.Fatalln("could not initialise file system analyser:", err)
 		}
@@ -109,7 +117,7 @@ func main() {
 		if image == "" {
 			image = analyser.DockerDefaultImage
 		}
-		analyse, err = analyser.NewDocker(image)
+		analyse, err = analyser.NewDocker(image, int(analyserMemoryLimit))
 		if err != nil {
 			log.Fatalln("could not initialise Docker analyser:", err)
 		}


### PR DESCRIPTION
Previously any tool running could consume all available RAM
and swap causing availability issues if the offending process
isn't terminated quickly.

This change adds a configuration parameter to limit the amount
of RAM a process can use. If it exceeds this limit, the process
is terminated, but other processes can continue.

Although we have a Filesystem analyser, which can only limit
memory usage via ulimit, the Docker analyser also uses this
mechanism because Docker's own memory limit will terminate the
container, not just the offending process. I.e. the limit cannot
be applied to our exec instance, only when we've created the
container.

We're also required to run the ulimit command each time, because
each tool is executed with a new shell, which won't inherit the
limits put in place by previous commands.

Fixes #106.