### PR TITLE
Analysis page to show output 

### DIFF
--- a/internal/analyser/cloner_test.go
+++ b/internal/analyser/cloner_test.go
@@ -15,7 +15,7 @@ func TestPullRequestCloner(t *testing.T) {
 		BaseURL: "base-url",
 	}
 
-	passExec := &mockAnalyser{
+	passExec := &mockExecuter{
 		ExecuteOut: [][]byte{{}, {}},
 		ExecuteErr: []error{nil, nil},
 	}
@@ -25,21 +25,21 @@ func TestPullRequestCloner(t *testing.T) {
 	}
 
 	// clone failed
-	cloneFailExec := &mockAnalyser{
+	cloneFailExec := &mockExecuter{
 		ExecuteOut: [][]byte{{}},
 		ExecuteErr: []error{errors.New("clone fail")},
 	}
 	cloneFailErr := errors.New(`could not execute [git clone --depth 1000 --branch head-ref --single-branch head-url .]: "": clone fail`)
 
 	// fetch failed
-	fetchFailExec := &mockAnalyser{
+	fetchFailExec := &mockExecuter{
 		ExecuteOut: [][]byte{{}, {}},
 		ExecuteErr: []error{nil, errors.New("fetch fail")},
 	}
 	fetchFailErr := errors.New(`could not execute [git fetch --depth 1000 base-url base-ref]: "": fetch fail`)
 
 	tests := []struct {
-		executer *mockAnalyser
+		executer *mockExecuter
 		wantArgs [][]string // nil to not check for args
 		wantErr  error
 	}{
@@ -66,7 +66,7 @@ func TestPushCloner(t *testing.T) {
 		HeadURL: "head-url",
 	}
 
-	passExec := &mockAnalyser{
+	passExec := &mockExecuter{
 		ExecuteOut: [][]byte{{}, {}},
 		ExecuteErr: []error{nil, nil},
 	}
@@ -76,21 +76,21 @@ func TestPushCloner(t *testing.T) {
 	}
 
 	// clone failed
-	cloneFailExec := &mockAnalyser{
+	cloneFailExec := &mockExecuter{
 		ExecuteOut: [][]byte{{}},
 		ExecuteErr: []error{errors.New("clone fail")},
 	}
 	cloneFailErr := errors.New(`could not execute [git clone head-url .]: "": clone fail`)
 
 	// checkout failed
-	coFailExec := &mockAnalyser{
+	coFailExec := &mockExecuter{
 		ExecuteOut: [][]byte{{}, {}},
 		ExecuteErr: []error{nil, errors.New("checkout fail")},
 	}
 	coFailErr := errors.New(`could not execute [git checkout head-ref]: "": checkout fail`)
 
 	tests := []struct {
-		executer *mockAnalyser
+		executer *mockExecuter
 		wantArgs [][]string // nil to not check for args
 		wantErr  error
 	}{

--- a/internal/analyser/configReader_test.go
+++ b/internal/analyser/configReader_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestYAMLConfig_default(t *testing.T) {
-	exec := &mockAnalyser{
+	exec := &mockExecuter{
 		ExecuteOut: [][]byte{{}},
 		ExecuteErr: []error{&NonZeroError{ExitCode: 1}},
 	}
@@ -31,7 +31,7 @@ func TestYAMLConfig_default(t *testing.T) {
 }
 
 func TestYAMLConfig_unknownError(t *testing.T) {
-	exec := &mockAnalyser{
+	exec := &mockExecuter{
 		ExecuteOut: [][]byte{{}},
 		ExecuteErr: []error{errors.New("unknown error")},
 	}
@@ -45,7 +45,7 @@ func TestYAMLConfig_unknownError(t *testing.T) {
 
 func TestYAMLConfig_unmarshalError(t *testing.T) {
 	contents := []byte("\t")
-	exec := &mockAnalyser{
+	exec := &mockExecuter{
 		ExecuteOut: [][]byte{contents},
 		ExecuteErr: []error{nil},
 	}
@@ -62,7 +62,7 @@ func TestYAMLConfig(t *testing.T) {
 apt_packages:
     - package1
 `)
-	exec := &mockAnalyser{
+	exec := &mockExecuter{
 		ExecuteOut: [][]byte{contents},
 		ExecuteErr: []error{nil},
 	}

--- a/internal/analyser/refReader_test.go
+++ b/internal/analyser/refReader_test.go
@@ -11,7 +11,7 @@ func TestMergeBase(t *testing.T) {
 
 	refReader := &MergeBase{}
 
-	passExec := &mockAnalyser{
+	passExec := &mockExecuter{
 		ExecuteOut: [][]byte{[]byte("abcdef\n")},
 		ExecuteErr: []error{nil},
 	}
@@ -19,14 +19,14 @@ func TestMergeBase(t *testing.T) {
 		{"git", "merge-base", "FETCH_HEAD", "HEAD"},
 	}
 
-	readerFailExec := &mockAnalyser{
+	readerFailExec := &mockExecuter{
 		ExecuteOut: [][]byte{{}},
 		ExecuteErr: []error{errors.New("git merge-base fail")},
 	}
 	readerFailErr := errors.New(`could not execute [git merge-base FETCH_HEAD HEAD]: "": git merge-base fail`)
 
 	tests := []struct {
-		executer *mockAnalyser
+		executer *mockExecuter
 		wantArgs [][]string // nil to not check for args
 		wantErr  error
 	}{

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,6 +28,8 @@ type DB interface {
 	// GetAnalysis returns an analysis for a given analysisID, returns nil if no
 	// analysis was found, or an error occurs.
 	GetAnalysis(analysisID int) (*Analysis, error)
+	// AnalysisOutputs returns the ordered output from the database.
+	AnalysisOutputs(analysisID int) ([]Output, error)
 	// ExecRecorder records the analysis in the database by wrapping the executer.
 	ExecRecorder(analysisID int, exec Executer) Executer
 }
@@ -118,6 +120,15 @@ func (d Duration) Value() (driver.Value, error) {
 // String implements the fmt.Stringer interface.
 func (d Duration) String() string {
 	return time.Duration(d).String()
+}
+
+// Output represents a row in the outputs table.
+type Output struct {
+	ID         int      `db:"id"`
+	AnalysisID int      `db:"analysis_id"`
+	Arguments  string   `db:"arguments"`
+	Duration   Duration `db:"duration"` // Duration is the wall clock time taken to run.
+	Output     string   `db:"output"`
 }
 
 // Analysis represents a single analysis of a repository at a point in time.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,6 +28,8 @@ type DB interface {
 	// GetAnalysis returns an analysis for a given analysisID, returns nil if no
 	// analysis was found, or an error occurs.
 	GetAnalysis(analysisID int) (*Analysis, error)
+	// ExecRecorder records the analysis in the database by wrapping the executer.
+	ExecRecorder(analysisID int, exec Executer) Executer
 }
 
 // AnalysisStatus represents a status in the analysis table.

--- a/internal/db/mockdb.go
+++ b/internal/db/mockdb.go
@@ -82,6 +82,11 @@ func (db *MockDB) GetAnalysis(analysisID int) (*Analysis, error) {
 	return nil, nil
 }
 
+// AnalysisOutputs implements the DB interface.
+func (db *MockDB) AnalysisOutputs(analysisID int) ([]Output, error) {
+	return nil, nil
+}
+
 // ExecRecorder implements the DB interface.
 func (db *MockDB) ExecRecorder(analysisID int, executer Executer) Executer {
 	return executer

--- a/internal/db/mockdb.go
+++ b/internal/db/mockdb.go
@@ -81,3 +81,8 @@ func (db *MockDB) FinishAnalysis(analysisID int, status AnalysisStatus, analysis
 func (db *MockDB) GetAnalysis(analysisID int) (*Analysis, error) {
 	return nil, nil
 }
+
+// ExecRecorder implements the DB interface.
+func (db *MockDB) ExecRecorder(analysisID int, executer Executer) Executer {
+	return executer
+}

--- a/internal/db/sqldb.go
+++ b/internal/db/sqldb.go
@@ -236,6 +236,13 @@ LEFT JOIN issues i ON (i.analysis_tool_id = at.id)
 	return analysis, nil
 }
 
+// AnalysisOutputs implements the DB interface.
+func (db *SQLDB) AnalysisOutputs(analysisID int) ([]Output, error) {
+	var tools []Output
+	err := db.sqlx.Select(&tools, "SELECT id, analysis_id, arguments, duration, output FROM outputs WHERE analysis_id = ? ORDER BY id ASC", analysisID)
+	return tools, err
+}
+
 // ExecRecorder implements the DB interface.
 func (db *SQLDB) ExecRecorder(analysisID int, executer Executer) Executer {
 	return &SQLExecuteWriter{

--- a/internal/db/sqldb_test.go
+++ b/internal/db/sqldb_test.go
@@ -1,0 +1,27 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTrim(t *testing.T) {
+	b := []byte("Go is a general-purpose language designed with systems programming in mind.")
+
+	tests := []struct {
+		max  int
+		want []byte
+	}{
+		{len(b) + 100, []byte("Go is a general-purpose language designed with systems programming in mind.")},
+		{len(b), []byte("Go is a general-purpose language designed with systems programming in mind.")},
+		{10, []byte("Go is...65 bytes suppressed...mind.")},
+	}
+
+	for _, test := range tests {
+		have := trim(b, test.max)
+		if diff := cmp.Diff(string(have), string(test.want)); diff != "" {
+			t.Errorf("not equal (-have +want)\n%s", diff)
+		}
+	}
+}

--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -390,6 +390,9 @@ func (g *GitHub) Analyse(cfg AnalyseConfig) (err error) {
 		}
 	}()
 
+	// Wrap it with our DB as it wants to record the results.
+	executer = g.db.ExecRecorder(analysis.ID, executer)
+
 	err = analyser.Analyse(ctx, executer, cfg.cloner, configReader, cfg.refReader, acfg, analysis)
 	if err != nil {
 		return errors.Wrap(err, "could not run analyser")

--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -372,15 +372,25 @@ func (g *GitHub) Analyse(cfg AnalyseConfig) (err error) {
 
 	// Analyse
 	acfg := analyser.Config{
-		HeadRef:   cfg.headRef,
-		GoSrcPath: cfg.goSrcPath,
+		HeadRef: cfg.headRef,
 	}
 
 	configReader := &analyser.YAMLConfig{
 		Tools: tools,
 	}
 
-	err = analyser.Analyse(ctx, g.analyser, cfg.cloner, configReader, cfg.refReader, acfg, analysis)
+	// Get a new executer/environment to execute in
+	executer, err := g.analyser.NewExecuter(ctx, cfg.goSrcPath)
+	if err != nil {
+		return errors.Wrap(err, "analyser could create new executer")
+	}
+	defer func() {
+		if err := executer.Stop(ctx); err != nil {
+			log.Printf("warning: could not stop executer: %v", err)
+		}
+	}()
+
+	err = analyser.Analyse(ctx, executer, cfg.cloner, configReader, cfg.refReader, acfg, analysis)
 	if err != nil {
 		return errors.Wrap(err, "could not run analyser")
 	}

--- a/internal/web/static/site.css
+++ b/internal/web/static/site.css
@@ -47,8 +47,11 @@ footer { text-align: center; background-color: #f5f5f5; padding: 40px 20px; bord
     background: #fff0da;
 }
 
+/* extra-cont is a container for patches/output paadding */
+.extra-cont { padding-top: 2em; }
+.extra-cont:last-child { padding-bottom: 2em; }
+
 /* Analysis Hunk */
-.issues-cont { padding: 2em 0; }
 .patch {
 	width: 100%;
 	margin: 0 auto 2rem;
@@ -67,3 +70,29 @@ footer { text-align: center; background-color: #f5f5f5; padding: 40px 20px; bord
 .patch .lno { text-align: right; background-color: rgba(250, 251, 252, 0.3); user-select: none; }
 .patch .range { background-color: #f3f8ff; }
 .patch tfoot tr:first-child { border-top: 1px solid #d7d7d7; }
+
+/* Analysis Outputs */
+.outputs-cont { padding-top: 2em; }
+.outputs {
+	font-family: Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+	font-size: 90%;
+	background-color: #292b2c;
+    padding: 1em 1em 0.5em;
+    margin-bottom: 2rem;
+    color: #a9a9a9;
+}
+.output-cont { position: relative; padding-bottom: 0.5rem; margin-bottom: 0; }
+.outputs .arg {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+	color: #e8e8e8;
+}
+.outputs .duration {
+	text-align: right;
+    display: block;
+    right: 0;
+    position: absolute;
+    top: 0;
+}
+.outputs .output { white-space: pre; display: block; }

--- a/internal/web/templates/analysis.tmpl
+++ b/internal/web/templates/analysis.tmpl
@@ -77,7 +77,7 @@
 
 <!-- Patches may not be set because of an error getting diffs, or there were no issues -->
 {{ if .Patches }}
-    <div class="container issues-cont">
+    <div class="container extra-cont">
         <h2>Issues</h2>
 
         {{ range .Patches }}
@@ -105,6 +105,22 @@
             </tbody>
         </table>
         {{ end }}
+    </div>
+{{ end }}
+
+<!-- Output may not be set if they've been pruned from the database -->
+{{ if .Outputs }}
+    <div class="container extra-cont">
+        <h2>Output</h2>
+        <div class="outputs">
+            {{ range .Outputs }}
+                <p class="output-cont">
+                    <span class="arg">$ {{ .Arguments }}</span>
+                    <span class="duration">{{ .Duration }}</span>
+                    <span class="output">{{ .Output }}</span>
+                </p>
+            {{ end }}
+        </div>
     </div>
 {{ end }}
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -80,6 +80,13 @@ func (web *Web) AnalysisHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	outputs, err := web.db.AnalysisOutputs(analysis.ID)
+	if err != nil {
+		log.Printf("error getting analysis output for analysis ID %v: %v", analysis.ID, err)
+		web.errorHandler(w, r, http.StatusInternalServerError, "Could not get analysis output")
+		return
+	}
+
 	vcs, err := NewVCS(web.gh, analysis)
 	if err != nil {
 		log.Printf("error getting VCS for analysisID %v: %v", analysisID, err)
@@ -116,11 +123,13 @@ func (web *Web) AnalysisHandler(w http.ResponseWriter, r *http.Request) {
 		Title       string
 		Analysis    *db.Analysis
 		Patches     []Patch
+		Outputs     []db.Output
 		TotalIssues int
 	}{
 		Title:       "Analysis",
 		Analysis:    analysis,
 		Patches:     patches,
+		Outputs:     outputs,
 		TotalIssues: len(analysis.Issues()),
 	}
 

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ func main() {
 	if err != nil {
 		log.Fatalln("could not initialise db:", err)
 	}
+	db.Cleanup(ctx)
 
 	var analyserMemoryLimit int64
 	if os.Getenv("ANALYSER_MEMORY_LIMIT") != "" {

--- a/migrations/7_outputs.sql
+++ b/migrations/7_outputs.sql
@@ -1,0 +1,14 @@
+-- +migrate Up
+CREATE TABLE outputs (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    analysis_id INT UNSIGNED NOT NULL,
+    arguments VARCHAR(2048) NOT NULL,
+    duration TIME(3) NOT NULL,
+    output TEXT NOT NULL,
+    PRIMARY KEY (id),
+    KEY (analysis_id),
+    FOREIGN KEY (analysis_id) REFERENCES analysis(id) ON DELETE CASCADE
+);
+
+-- +migrate Down
+DROP TABLE outputs;


### PR DESCRIPTION
Analysis to accept an Executer instead of creating its own

```
Previously I was trying to keep as much logic out of the GitHub
specific handler as I could that wasn't directly GitHub related.
So the analyser creating its own execution environment was OK
initially. But it's added some knowledge the Analyser doesn't
require, and eventually the analyser will be refactored more into
its own parts the the Analyse method may just run a single tool
and a constructor will prepare the environment for the tools.

Also, we'll soon be wanting to wrap/decorate the Executer to have
the database log the output of all the commands being issued.

So the GitHub handler, that already knew about the analyser keeps
that knowledge to itself and just passes a working executor and
manages the clean up itself.
```

db.DB to provide an analysis.Executer for recording executions

```
DB must now implement a mechanism to record (or discard) results
of an Execution. This is because the user operating GopherCI and
the user viewing the results of a CI analysis may be different
people with different access, when an error occurrs, previously
only the operator would see the error, not the user who may be
able to fix it.

We need a mechanism for user's to view the results of an Execution,
including the output. This is done by requiring the database to
provide an analysis.Executer that the analysis can then wrap/decorate
a real executer, to record the output.
```

Analysis page to show outputs of analysis

![runners dev1 gopherci io-analysis-415](https://user-images.githubusercontent.com/1834577/29011940-6b8fd46e-7b76-11e7-9539-5d211daf530f.png)

Fixes #88.