### PR TITLE
Show environment information in analysis output

### DIFF
--- a/internal/analyser/analyser.go
+++ b/internal/analyser/analyser.go
@@ -79,6 +79,20 @@ func Analyse(ctx context.Context, exec Executer, cloner Cloner, configReader Con
 		return errors.WithMessage(err, "could not configure repository")
 	}
 
+	// Show environment
+	envArgs := [][]string{
+		{"go", "env"},
+		{"go", "version"},
+		{"cat", "/proc/self/limits"},
+		{"lsb_release", "--description"},
+	}
+	for _, arg := range envArgs {
+		out, err := exec.Execute(ctx, arg)
+		if err != nil {
+			return fmt.Errorf("could not execute %v: %s\n%s", arg, err, out)
+		}
+	}
+
 	// install packages
 	if err := installAPTPackages(ctx, exec, repoConfig.APTPackages); err != nil {
 		return errors.WithMessage(err, "could not install packages")

--- a/internal/analyser/analyser_test.go
+++ b/internal/analyser/analyser_test.go
@@ -59,6 +59,10 @@ index 0000000..6362395
 
 	analyser := &mockExecuter{
 		ExecuteOut: [][]byte{
+			{},   // go env
+			{},   // go version
+			{},   // cat /proc/self/limits
+			{},   // lsb_release --description
 			{},   // installAPTPackages
 			diff, // git diff
 			{},   // install-deps.sh
@@ -71,6 +75,10 @@ index 0000000..6362395
 			[]byte("file is generated"),                  // isFileGenerated
 		},
 		ExecuteErr: []error{
+			nil, // go env
+			nil, // go version
+			nil, // cat /proc/self/limits
+			nil, // lsb_release --description
 			nil, // installAPTPackages
 			nil, // git diff
 			nil, // install-deps.sh
@@ -119,6 +127,10 @@ index 0000000..6362395
 	}
 
 	expectedArgs := [][]string{
+		{"go", "env"},
+		{"go", "version"},
+		{"cat", "/proc/self/limits"},
+		{"lsb_release", "--description"},
 		{"apt-get", "install", "-y", "package1"},
 		{"git", "diff", fmt.Sprintf("%s...%v", refReader.BaseRef, cfg.HeadRef)},
 		{"install-deps.sh"},


### PR DESCRIPTION
Summary page now shows the output of all process run, it'll be
helpful for users to see:

- Go version: we change this on behalf of the user as newer versions
are released, and may allow users to chose a version later.
- Go environment: we may need to adjust some environment parameters
to support different versions and other options that the user may
need to be aware of.
- Limits: we limit the maximum virtual memory a process can use and
other limits are in place, users should be able to see these limits.
- OS Release: users have the ability to install apt packages, as a
result they will need to at least know the distribution version to
know the package names.

We output the versions after (attempting) to read the config file so
future versions that change the environment (such as different Go
versions) will have the status reflect their configuration.

Resolves #107.