### PR TITLE
Refactor into Reporter Interface

### DIFF
--- a/internal/analyser/reporter.go
+++ b/internal/analyser/reporter.go
@@ -1,0 +1,26 @@
+package analyser
+
+import (
+	"context"
+
+	"github.com/bradleyfalzon/gopherci/internal/db"
+)
+
+// A Reporter reports the issues.
+type Reporter interface {
+	Report(context.Context, []db.Issue) error
+}
+
+// MaxIssueComments is the maximum number of comments that will be written
+// on a pull request by writeissues. a pr may have more comments written if
+// writeissues is called multiple times, such is multiple syncronise events.
+const MaxIssueComments = 10
+
+// Suppress returns a maximum amount of issues, if any are suppressed the total
+// number suppressed is also returned.
+func Suppress(issues []db.Issue, max int) (int, []db.Issue) {
+	if len(issues) > max {
+		return len(issues) - max, issues[:max]
+	}
+	return 0, issues
+}

--- a/internal/analyser/reporter_test.go
+++ b/internal/analyser/reporter_test.go
@@ -1,0 +1,41 @@
+package analyser
+
+import (
+	"testing"
+
+	"github.com/bradleyfalzon/gopherci/internal/db"
+)
+
+func TestSuppress(t *testing.T) {
+	tests := []struct {
+		suppress  int // number of issues to suppress
+		genIssues int // number of issues to generate
+	}{
+		{suppress: 1, genIssues: MaxIssueComments + 1},
+		{suppress: 0, genIssues: MaxIssueComments},
+		{suppress: 0, genIssues: MaxIssueComments - 1},
+	}
+
+	for _, test := range tests {
+		// Number of issues to suppress
+		//suppress := 1
+
+		// Add more issues than maxIssueComments
+		var issues []db.Issue
+		for n := 0; n < test.genIssues; n++ {
+			//for n := 0; n < MaxIssueComments+suppress; n++ {
+			issues = append(issues, db.Issue{Path: "file.go", HunkPos: n, Issue: "body"})
+		}
+
+		suppressed, filtered := Suppress(issues, MaxIssueComments)
+
+		// Ensure we don't send more comments than maxIssueComments
+		if len(filtered) > MaxIssueComments {
+			t.Errorf("filtered comment count %v is greater than MaxIssueComments %v", len(filtered), MaxIssueComments)
+		}
+
+		if suppressed != test.suppress {
+			t.Errorf("suppressed have %v want %v", suppressed, test.suppress)
+		}
+	}
+}

--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -741,24 +741,3 @@ func TestStripScheme(t *testing.T) {
 		}
 	}
 }
-
-func TestStatusDesc(t *testing.T) {
-	tests := []struct {
-		issues     []db.Issue
-		suppressed int
-		want       string
-	}{
-		{[]db.Issue{{}, {}}, 2, "Found 2 issues (2 comments suppressed)"},
-		{[]db.Issue{{}, {}}, 1, "Found 2 issues (1 comment suppressed)"},
-		{[]db.Issue{{}, {}}, 0, "Found 2 issues"},
-		{[]db.Issue{{}}, 0, "Found 1 issue"},
-		{[]db.Issue{}, 0, `Found no issues \ʕ◔ϖ◔ʔ/`},
-	}
-
-	for _, test := range tests {
-		have := statusDesc(test.issues, test.suppressed)
-		if have != test.want {
-			t.Errorf("have: %v want: %v", have, test.want)
-		}
-	}
-}

--- a/internal/github/installation.go
+++ b/internal/github/installation.go
@@ -1,9 +1,7 @@
 package github
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -54,50 +52,6 @@ func (g *GitHub) NewInstallation(installationID int) (*Installation, error) {
 // IsEnabled returns true if an installation is enabled.
 func (i *Installation) IsEnabled() bool {
 	return i != nil
-}
-
-// StatusState is the state of a GitHub Status API as defined in
-// https://developer.github.com/v3/repos/statuses/
-type StatusState string
-
-const (
-	StatusStatePending StatusState = "pending"
-	StatusStateSuccess StatusState = "success"
-	StatusStateError   StatusState = "error"
-	StatusStateFailure StatusState = "failure"
-)
-
-// SetStatus sets the CI Status API
-func (i *Installation) SetStatus(ctx context.Context, context, statusURL string, status StatusState, description, targetURL string) error {
-	s := struct {
-		State       string `json:"state,omitempty"`
-		TargetURL   string `json:"target_url,omitempty"`
-		Description string `json:"description,omitempty"`
-		Context     string `json:"context,omitempty"`
-	}{
-		string(status), targetURL, description, context,
-	}
-	log.Printf("status: %#v", status)
-
-	js, err := json.Marshal(&s)
-	if err != nil {
-		return errors.Wrap(err, "could not marshal status")
-	}
-
-	req, err := http.NewRequest("POST", statusURL, bytes.NewBuffer(js))
-	if err != nil {
-		return err
-	}
-	resp, err := i.client.Do(ctx, req, nil)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("received status code %v", resp.StatusCode)
-	}
-	return nil
 }
 
 // Diff implements the web.VCSReader interface.

--- a/internal/github/installation_test.go
+++ b/internal/github/installation_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,7 +10,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bradleyfalzon/gopherci/internal/db"
 	"github.com/google/go-github/github"
 )
 
@@ -23,144 +21,6 @@ func TestInstallation_isEnabled(t *testing.T) {
 	i = &Installation{}
 	if want := true; i.IsEnabled() != want {
 		t.Errorf("want: %v, have: %v", want, i.IsEnabled())
-	}
-}
-
-func TestFilterIssues_maxIssueComments(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	defer ts.Close()
-
-	i := Installation{client: github.NewClient(nil)}
-	i.client.BaseURL, _ = url.Parse(ts.URL)
-
-	// Number of issues to suppress
-	suppress := 1
-
-	// Add more issues than maxIssueComments
-	var issues []db.Issue
-	for n := 0; n < maxIssueComments+suppress; n++ {
-		issues = append(issues, db.Issue{Path: "file.go", HunkPos: n, Issue: "body"})
-	}
-
-	suppressed, filtered, err := i.FilterIssues(context.Background(), "owner", "repo", 2, issues)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Ensure we don't send more comments than maxIssueComments
-	if len(filtered) > maxIssueComments {
-		t.Errorf("filtered comment count %v is greater than maxIssueComments %v", len(filtered), maxIssueComments)
-	}
-
-	if suppressed != suppress {
-		t.Errorf("suppressed have %v want %v", suppressed, suppress)
-	}
-}
-
-func TestFilterIssues_deduplicate(t *testing.T) {
-	var (
-		expectedOwner   = "owner"
-		expectedRepo    = "repo"
-		expectedPR      = 2
-		expectedCmtBody = "body"
-		expectedCmtPath = "path.go"
-		expectedCmtPos  = 4
-	)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.RequestURI {
-		case fmt.Sprintf("/repos/%v/%v/pulls/%v/comments", expectedOwner, expectedRepo, expectedPR):
-			comments := []*github.PullRequestComment{
-				{
-					Body:     nil, // nil check
-					Path:     nil, // nil check
-					Position: nil, // nil check
-				},
-				{
-					Body:     github.String(expectedCmtBody),
-					Path:     github.String(expectedCmtPath),
-					Position: github.Int(expectedCmtPos),
-				},
-				{
-					Body:     github.String(expectedCmtBody),
-					Path:     github.String(expectedCmtPath),
-					Position: github.Int(expectedCmtPos + 2),
-				},
-				{
-					// Duplicate comment
-					Body:     github.String(expectedCmtBody),
-					Path:     github.String(expectedCmtPath),
-					Position: github.Int(expectedCmtPos + 2),
-				},
-			}
-			json, _ := json.Marshal(comments)
-			fmt.Fprint(w, string(json))
-		}
-	}))
-	defer ts.Close()
-
-	i := Installation{client: github.NewClient(nil)}
-	i.client.BaseURL, _ = url.Parse(ts.URL)
-
-	var issues = []db.Issue{
-		{Path: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody},     // remove
-		{Path: expectedCmtPath, HunkPos: expectedCmtPos + 1, Issue: expectedCmtBody}, // keep
-		{Path: expectedCmtPath, HunkPos: expectedCmtPos + 2, Issue: expectedCmtBody}, // remove
-	}
-
-	_, filtered, err := i.FilterIssues(context.Background(), expectedOwner, expectedRepo, expectedPR, issues)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if want := 1; len(filtered) != want {
-		t.Errorf("filtered comment count %v does not match %v", len(filtered), want)
-	}
-}
-
-func TestWriteIssues(t *testing.T) {
-	var (
-		expectedOwner   = "owner"
-		expectedRepo    = "repo"
-		expectedPR      = 2
-		expectedCmtBody = "body"
-		expectedCmtPath = "path"
-		expectedCmtPos  = 4
-		expectedCmtSHA  = "abc123"
-	)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		decoder := json.NewDecoder(r.Body)
-		switch r.RequestURI {
-		case fmt.Sprintf("/repos/%v/%v/pulls/%v/comments", expectedOwner, expectedRepo, expectedPR):
-			expected := github.PullRequestComment{
-				Body:     github.String(expectedCmtBody),
-				Path:     github.String(expectedCmtPath),
-				Position: github.Int(expectedCmtPos),
-				CommitID: github.String(expectedCmtSHA),
-			}
-			var comment github.PullRequestComment
-			err := decoder.Decode(&comment)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !reflect.DeepEqual(expected, comment) {
-				t.Fatalf("expected cmt:\n%#v\ngot:\n%#v", expected, comment)
-			}
-		default:
-			t.Logf(r.RequestURI)
-		}
-	}))
-	defer ts.Close()
-
-	i := Installation{client: github.NewClient(nil)}
-	i.client.BaseURL, _ = url.Parse(ts.URL)
-
-	var issues = []db.Issue{{Path: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody}}
-
-	err := i.WriteIssues(context.Background(), expectedOwner, expectedRepo, expectedPR, expectedCmtSHA, issues)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/github/reporters.go
+++ b/internal/github/reporters.go
@@ -1,0 +1,88 @@
+package github
+
+import (
+	"context"
+
+	"github.com/bradleyfalzon/gopherci/internal/analyser"
+	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/google/go-github/github"
+	"github.com/pkg/errors"
+)
+
+// PRCommentReporter is a analyser.Reporter that creates a pull request comment
+// for each issue on a given owner, repo, pr and commit hash. Returns on the
+// first error encountered.
+type PRCommentReporter struct {
+	client *github.Client
+	owner  string
+	repo   string
+	number int
+	commit string
+}
+
+var _ analyser.Reporter = &PRCommentReporter{}
+
+// NewPRCommentReporter returns a PRCommentReporter.
+func NewPRCommentReporter(client *github.Client, owner, repo string, number int, commit string) *PRCommentReporter {
+	return &PRCommentReporter{
+		client: client,
+		owner:  owner,
+		repo:   repo,
+		number: number,
+		commit: commit,
+	}
+}
+
+// FilterIssues deduplicates issues by checking the existing pull request for
+// existing comments and returns comments that don't already exist.
+func (r *PRCommentReporter) filterIssues(ctx context.Context, issues []db.Issue) (filtered []db.Issue, err error) {
+	ecomments, _, err := r.client.PullRequests.ListComments(ctx, r.owner, r.repo, r.number, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not list existing comments")
+	}
+
+	// remove duplicate comments, as we're remove elements based on the index
+	// start from last position and work backwards to keep indexes consistent
+	// even after removing elements.
+	for i := len(issues) - 1; i >= 0; i-- {
+		issue := issues[i]
+		for _, ec := range ecomments {
+			if ec.Path == nil || ec.Position == nil || ec.Body == nil {
+				continue
+			}
+			if issue.Path == *ec.Path && issue.HunkPos == *ec.Position && issue.Issue == *ec.Body {
+				issues = append(issues[:i], issues[i+1:]...)
+				break
+			}
+		}
+	}
+
+	return issues, nil
+}
+
+// Report implements the analyser.Reporter interface.
+func (r *PRCommentReporter) Report(ctx context.Context, issues []db.Issue) error {
+	filtered, err := r.filterIssues(ctx, issues)
+	if err != nil {
+		return err
+	}
+
+	_, issues = analyser.Suppress(filtered, analyser.MaxIssueComments)
+
+	for _, issue := range issues {
+		comment := &github.PullRequestComment{
+			Body:     github.String(issue.Issue),
+			CommitID: github.String(r.commit),
+			Path:     github.String(issue.Path),
+			Position: github.Int(issue.HunkPos),
+		}
+		_, _, err := r.client.PullRequests.CreateComment(ctx, r.owner, r.repo, r.number, comment)
+		if err != nil {
+			return errors.Wrapf(err, "could not post comment path: %q, position: %v, commitID: %q, body: %q",
+				*comment.Path, *comment.Position, *comment.CommitID, *comment.Body,
+			)
+		}
+	}
+
+	return nil
+}

--- a/internal/github/reporters_test.go
+++ b/internal/github/reporters_test.go
@@ -1,0 +1,130 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/google/go-github/github"
+)
+
+func TestPRCommentReporter_filterIssues(t *testing.T) {
+	var (
+		expectedOwner   = "owner"
+		expectedRepo    = "repo"
+		expectedPR      = 2
+		expectedCmtBody = "body"
+		expectedCmtPath = "path.go"
+		expectedCmtPos  = 4
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case fmt.Sprintf("/repos/%v/%v/pulls/%v/comments", expectedOwner, expectedRepo, expectedPR):
+			comments := []*github.PullRequestComment{
+				{
+					Body:     nil, // nil check
+					Path:     nil, // nil check
+					Position: nil, // nil check
+				},
+				{
+					Body:     github.String(expectedCmtBody),
+					Path:     github.String(expectedCmtPath),
+					Position: github.Int(expectedCmtPos),
+				},
+				{
+					Body:     github.String(expectedCmtBody),
+					Path:     github.String(expectedCmtPath),
+					Position: github.Int(expectedCmtPos + 2),
+				},
+				{
+					// Duplicate comment
+					Body:     github.String(expectedCmtBody),
+					Path:     github.String(expectedCmtPath),
+					Position: github.Int(expectedCmtPos + 2),
+				},
+			}
+			json, _ := json.Marshal(comments)
+			fmt.Fprint(w, string(json))
+		}
+	}))
+	defer ts.Close()
+
+	r := NewPRCommentReporter(github.NewClient(nil), expectedOwner, expectedRepo, expectedPR, "")
+	r.client.BaseURL, _ = url.Parse(ts.URL)
+
+	var issues = []db.Issue{
+		{Path: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody},     // remove
+		{Path: expectedCmtPath, HunkPos: expectedCmtPos + 1, Issue: expectedCmtBody}, // keep
+		{Path: expectedCmtPath, HunkPos: expectedCmtPos + 2, Issue: expectedCmtBody}, // remove
+	}
+
+	filtered, err := r.filterIssues(context.Background(), issues)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if want := 1; len(filtered) != want {
+		t.Errorf("filtered comment count %v does not match %v", len(filtered), want)
+	}
+}
+
+func PRCommentReporter_report(t *testing.T) {
+	var (
+		expectedOwner   = "owner"
+		expectedRepo    = "repo"
+		expectedPR      = 2
+		expectedCmtBody = "body"
+		expectedCmtPath = "path"
+		expectedCmtPos  = 4
+		expectedCmtSHA  = "abc123"
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		decoder := json.NewDecoder(r.Body)
+		switch r.RequestURI {
+		case fmt.Sprintf("/repos/%v/%v/pulls/%v/comments", expectedOwner, expectedRepo, expectedPR):
+			if strings.ToLower(r.Method) == "get" {
+				// Call to ListComments
+				comments := []*github.PullRequestComment{}
+				json, _ := json.Marshal(comments)
+				fmt.Fprint(w, string(json))
+				break
+			}
+			expected := github.PullRequestComment{
+				Body:     github.String(expectedCmtBody),
+				Path:     github.String(expectedCmtPath),
+				Position: github.Int(expectedCmtPos),
+				CommitID: github.String(expectedCmtSHA),
+			}
+			var comment github.PullRequestComment
+			err := decoder.Decode(&comment)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(expected, comment) {
+				t.Fatalf("expected cmt:\n%#v\ngot:\n%#v", expected, comment)
+			}
+		default:
+			t.Logf(r.RequestURI)
+		}
+	}))
+	defer ts.Close()
+
+	r := NewPRCommentReporter(github.NewClient(nil), expectedOwner, expectedRepo, expectedPR, expectedCmtSHA)
+	r.client.BaseURL, _ = url.Parse(ts.URL)
+
+	var issues = []db.Issue{{Path: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody}}
+
+	err := r.Report(context.Background(), issues)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Previously the GitHub handler was solely responsible for reporting issues, but in the near future, the Analyser package will begin to be responsible for it.

To do this, we'll create an `analyser.Reporter` interface with a single method `Report(context.Context, []db.Issue) error`. GitHub handler is then responsible for determining which reporters it requires and then executing those reporters.

GitHub handler will still be responsible for calling the Report methods, but this will eventually change, and instead, GitHub handler will just be responsible for instantiating the types and passing them to Analyser.

This change is mostly moving the two reporters (Pull Request Comments and Status API) to their own types that implement the `analyser.Reporter` interface.

Additional reporters will be available in #75 (commit comments) and #112 (pull request reviews).

Included: Integration tests to test for states being set in order

```
Previously the github.Analyse test was responsible for testing that
the Status API states were being set in the correct order. This
complicated the testing and we'll shortly be duplicating some of that
functionality and tests into its own type.

In moving to its own type, we won't be able to track the order of
statuses, we want to see Pending be set first, followed by Success. The
unit tests will test to make sure the status API can set the status
correctly, but won't have visibility in the order they occur.

Instead, the integration tests, which are already checking the status
API statuses will be responsible to ensure the state transitions from
Pending to Success/Failure or Error.
```