### PR TITLE
Pull Request Reviews

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -106,7 +106,7 @@
   branch = "master"
   name = "github.com/google/go-github"
   packages = ["github"]
-  revision = "35d38108ba83757e9b6fc00e4ba7e2d597c651be"
+  revision = "6afafa88c26eb51b33a8307c944bd2f0ef227af7"
 
 [[projects]]
   branch = "master"

--- a/internal/github/reporters.go
+++ b/internal/github/reporters.go
@@ -38,10 +38,10 @@ func NewPRCommentReporter(client *github.Client, owner, repo string, number int,
 	}
 }
 
-// FilterIssues deduplicates issues by checking the existing pull request for
+// dedupePRIssues deduplicates issues by checking the existing pull request for
 // existing comments and returns comments that don't already exist.
-func (r *PRCommentReporter) filterIssues(ctx context.Context, issues []db.Issue) (filtered []db.Issue, err error) {
-	ecomments, _, err := r.client.PullRequests.ListComments(ctx, r.owner, r.repo, r.number, nil)
+func dedupePRIssues(ctx context.Context, client *github.Client, owner, repo string, number int, issues []db.Issue) (filtered []db.Issue, err error) {
+	ecomments, _, err := client.PullRequests.ListComments(ctx, owner, repo, number, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not list existing comments")
 	}
@@ -67,7 +67,7 @@ func (r *PRCommentReporter) filterIssues(ctx context.Context, issues []db.Issue)
 
 // Report implements the analyser.Reporter interface.
 func (r *PRCommentReporter) Report(ctx context.Context, issues []db.Issue) error {
-	filtered, err := r.filterIssues(ctx, issues)
+	filtered, err := dedupePRIssues(ctx, r.client, r.owner, r.repo, r.number, issues)
 	if err != nil {
 		return err
 	}

--- a/internal/github/reporters_test.go
+++ b/internal/github/reporters_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/go-github/github"
 )
 
-func TestPRCommentReporter_filterIssues(t *testing.T) {
+func TestDedupePRIssues(t *testing.T) {
 	var (
 		expectedOwner   = "owner"
 		expectedRepo    = "repo"
@@ -58,8 +58,8 @@ func TestPRCommentReporter_filterIssues(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	r := NewPRCommentReporter(github.NewClient(nil), expectedOwner, expectedRepo, expectedPR, "")
-	r.client.BaseURL, _ = url.Parse(ts.URL)
+	client := github.NewClient(nil)
+	client.BaseURL, _ = url.Parse(ts.URL)
 
 	var issues = []db.Issue{
 		{Path: expectedCmtPath, HunkPos: expectedCmtPos, Issue: expectedCmtBody},     // remove
@@ -67,7 +67,7 @@ func TestPRCommentReporter_filterIssues(t *testing.T) {
 		{Path: expectedCmtPath, HunkPos: expectedCmtPos + 2, Issue: expectedCmtBody}, // remove
 	}
 
-	filtered, err := r.filterIssues(context.Background(), issues)
+	filtered, err := dedupePRIssues(context.Background(), client, expectedOwner, expectedRepo, expectedPR, issues)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
GitHub add PRReviewReporter to post create Pull Request Reviews

```
PRReviewReporter uses GitHub's Pull Request Reviews to post issues,
there are multiple benefits, the main being multiple issues result
in just one email to the user.

Additionally, when no issues are detected, a review is still created
with the event APPROVE. This will become configurable at a later
stage as it results in an extra email.

Whilst possible to set the review event to REQUEST_CHANGES, this
hasn't been enabled yet, but will become a configuration option at
a later stage. Instead, the event is set to COMMENT if there are issues
found.
```

Relates to #112.

Going to wait on merging this until I can get a comment on https://platform.github.community/t/api-endpoint-for-pr-reviews/409/21, hopefully, won't be long.

EDIT: This PR used to contain the addition of `PRReviewReporter` **and** enabled it by default. As we're waiting on GitHub to confirm the endpoint is available, I'll just merge adding `PRReviewReporter` and leave enabling it by default in another PR. 