### PR TITLE
GitHub to post reviews using PRReviewReporter by default

### DIFF
--- a/internal/github/handlers.go
+++ b/internal/github/handlers.go
@@ -450,7 +450,7 @@ func (g *GitHub) Analyse(cfg AnalyseConfig) (err error) {
 	switch {
 	case cfg.pr != 0:
 		// Inline code comments on the PR.
-		reporters = append(reporters, NewPRCommentReporter(install.client, cfg.owner, cfg.repo, cfg.pr, cfg.sha))
+		reporters = append(reporters, NewPRReviewReporter(install.client, cfg.owner, cfg.repo, cfg.pr, cfg.sha))
 	case cfg.commitCount == 1:
 		// Comment on the single commit the issues inline.
 		reporters = append(reporters, NewInlineCommitCommentReporter(install.client, cfg.owner, cfg.repo, cfg.sha))

--- a/testdata/issue-no-comments.sh
+++ b/testdata/issue-no-comments.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -eux
+
+git checkout -b $1
+
+cat > foo.go <<EOF
+package foo
+EOF
+
+git add .
+git commit -m "commit"
+
+git push -f -u origin HEAD


### PR DESCRIPTION
```
For pull requests, this enables the Pull Request Review reporter to
approve pull requests or post comments if issues are found.

The unit test for GitHub has been simplified further to just check
if a comment has been made. In the future the github package won't
require this mocking at all as it will just provide reports to an
analyse function, and instead rely on the integration tests to ensure
issues are reported.

An additional integration test has been included to verify a review
is posted when there are no issues, and its state is APPROVED.
```

Resolves #112.