### PR TITLE
Provide application wide logger for structured, levelled with context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
+# Environment application is running in.
+# can be either:
+# production: debug is off, logs are structured json
+# development: debug is on, logs are structured text
+LOGGER_ENV=development
+
+# Set Sentry connection details provided by sentry.io or self hosted sentry.
+# Optional.
+# LOGGER_SENTRY_DSN=
+
 # URL prefix for GopherCI to refer back to itself, without trailing slash.
 GCI_BASE_URL=https://gci.gopherci.io
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,6 +44,12 @@
   version = "v0.2"
 
 [[projects]]
+  name = "github.com/certifi/gocertifi"
+  packages = ["."]
+  revision = "3fd9e1adb12b72d2f3f82191d49be9b93c69f67c"
+  version = "2017.07.27"
+
+[[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
   revision = "d2709f9f1f31ebcda9651b03077758c1f3a0018c"
@@ -67,10 +73,22 @@
   version = "v0.3.1"
 
 [[projects]]
+  name = "github.com/evalphobia/logrus_sentry"
+  packages = ["."]
+  revision = "9f8f2d05a621e616d9341ac75374eb8402ae0630"
+  version = "v0.4.1"
+
+[[projects]]
   branch = "master"
   name = "github.com/fsouza/go-dockerclient"
   packages = ["."]
   revision = "8462902e31da1644862169cd142c126223ecb38e"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/getsentry/raven-go"
+  packages = ["."]
+  revision = "d175f85701dfbf44cb0510114c9943e665e60907"
 
 [[projects]]
   name = "github.com/go-chi/chi"
@@ -249,6 +267,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "15b35dad52244b960d126be242aaf6a334a84d28a43ec606277671fb28ee66b4"
+  inputs-digest = "9f895e48b0f7c281dd14a0bca17d8427e5535ccbbd72f018272fb0c4186093db"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 deps:
 	dep ensure
+	mkdir -p ${GOPATH}/src/github.com/Sirupsen
+	mv vendor/github.com/Sirupsen/logrus ${GOPATH}/src/github.com/Sirupsen
 
 install:
 	go install

--- a/internal/analyser/analyser_test.go
+++ b/internal/analyser/analyser_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/bradleyfalzon/gopherci/internal/logger"
 )
 
 type mockExecuter struct {
@@ -107,7 +108,7 @@ index 0000000..6362395
 		},
 	}
 
-	err := Analyse(context.Background(), analyser, cloner, configReader, refReader, cfg, analysis)
+	err := Analyse(context.Background(), logger.Testing(), analyser, cloner, configReader, refReader, cfg, analysis)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}

--- a/internal/analyser/docker_test.go
+++ b/internal/analyser/docker_test.go
@@ -3,14 +3,15 @@ package analyser
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"testing"
+
+	"github.com/bradleyfalzon/gopherci/internal/logger"
 )
 
 func TestDocker(t *testing.T) {
 	memLimit := 512
-	docker, err := NewDocker(DockerDefaultImage, memLimit)
+	docker, err := NewDocker(logger.Testing(), DockerDefaultImage, memLimit)
 	if err != nil {
 		t.Fatalf("unexpected error initialising docker: %v", err)
 	}
@@ -42,7 +43,6 @@ func TestDocker(t *testing.T) {
 
 	// Ensure error codes are captured
 	out, err = exec.Execute(ctx, []string{">&2 echo error; false"})
-	log.Printf("%q %q", string(out), err)
 	if want := "error\n"; want != string(out) {
 		t.Errorf("\nwant: %q\nhave: %q", want, out)
 	}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -6,11 +6,13 @@ import (
 	"github.com/bradleyfalzon/ghinstallation"
 	"github.com/bradleyfalzon/gopherci/internal/analyser"
 	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/bradleyfalzon/gopherci/internal/logger"
 	"github.com/sethgrid/pester"
 )
 
 // GitHub is the type gopherci uses to interract with github.com.
 type GitHub struct {
+	logger         logger.Logger
 	db             db.DB
 	analyser       analyser.Analyser
 	queuePush      chan<- interface{}
@@ -27,8 +29,9 @@ type GitHub struct {
 // integrationID is the GitHub Integration ID (not installation ID).
 // integrationKey is the key for the integrationID provided to you by GitHub
 // during the integration registration.
-func New(analyser analyser.Analyser, db db.DB, queuePush chan<- interface{}, integrationID int, integrationKey []byte, webhookSecret, gciBaseURL string) (*GitHub, error) {
+func New(logger logger.Logger, analyser analyser.Analyser, db db.DB, queuePush chan<- interface{}, integrationID int, integrationKey []byte, webhookSecret, gciBaseURL string) (*GitHub, error) {
 	g := &GitHub{
+		logger:         logger,
 		analyser:       analyser,
 		db:             db,
 		queuePush:      queuePush,

--- a/internal/github/handlers_test.go
+++ b/internal/github/handlers_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/bradleyfalzon/gopherci/internal/analyser"
 	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/bradleyfalzon/gopherci/internal/logger"
 	"github.com/bradleyfalzon/gopherci/internal/queue"
 	"github.com/google/go-github/github"
 )
@@ -86,11 +87,11 @@ func setup(t *testing.T) (*GitHub, *mockAnalyser, *db.MockDB) {
 		wg sync.WaitGroup
 		c  = make(chan interface{})
 	)
-	queue := queue.NewMemoryQueue()
+	queue := queue.NewMemoryQueue(logger.Testing())
 	queue.Wait(context.Background(), &wg, c, func(job interface{}) {})
 
 	// New GitHub
-	g, err := New(mockAnalyser, memDB, c, 1, integrationKey, webhookSecret, "https://example.com")
+	g, err := New(logger.Testing(), mockAnalyser, memDB, c, 1, integrationKey, webhookSecret, "https://example.com")
 	if err != nil {
 		t.Fatal("could not initialise GitHub:", err)
 	}

--- a/internal/github/installation.go
+++ b/internal/github/installation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -31,7 +30,6 @@ func (g *GitHub) NewInstallation(installationID int) (*Installation, error) {
 		return nil, nil
 	}
 	if !installation.IsEnabled() {
-		log.Printf("ignoring disabled installation: %+v", installation)
 		return nil, nil
 	}
 

--- a/internal/github/reporters.go
+++ b/internal/github/reporters.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/bradleyfalzon/gopherci/internal/analyser"
 	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/bradleyfalzon/gopherci/internal/logger"
 	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
 )
@@ -107,6 +107,7 @@ const (
 // StatusAPIReporter uses the GitHub Statuses API to report build status, such
 // as success or failure.
 type StatusAPIReporter struct {
+	logger    logger.Logger
 	client    *github.Client
 	statusURL string
 	context   string
@@ -116,8 +117,9 @@ type StatusAPIReporter struct {
 var _ analyser.Reporter = &StatusAPIReporter{}
 
 // NewStatusAPIReporter returns a StatusAPIReporter.
-func NewStatusAPIReporter(client *github.Client, statusURL, context, targetURL string) *StatusAPIReporter {
+func NewStatusAPIReporter(logger logger.Logger, client *github.Client, statusURL, context, targetURL string) *StatusAPIReporter {
 	return &StatusAPIReporter{
+		logger:    logger,
 		client:    client,
 		statusURL: statusURL,
 		context:   context,
@@ -136,7 +138,7 @@ func (r *StatusAPIReporter) SetStatus(ctx context.Context, status StatusState, d
 		string(status), r.targetURL, description, r.context,
 	}
 
-	log.Printf("Setting %v state: %q, context: %q, description: %q", r.statusURL, status, r.context, description)
+	r.logger.Infof("Setting %v state: %q, context: %q, description: %q", r.statusURL, status, r.context, description)
 
 	js, err := json.Marshal(&s)
 	if err != nil {

--- a/internal/github/reporters_test.go
+++ b/internal/github/reporters_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/bradleyfalzon/gopherci/internal/db"
+	"github.com/bradleyfalzon/gopherci/internal/logger"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/github"
 )
@@ -161,7 +162,7 @@ func TestStatusAPIReporter_SetStatus(t *testing.T) {
 		Context:     "context",
 	}
 
-	r := NewStatusAPIReporter(github.NewClient(nil), statusURL, want.Context, want.TargetURL)
+	r := NewStatusAPIReporter(logger.Testing(), github.NewClient(nil), statusURL, want.Context, want.TargetURL)
 	r.SetStatus(context.Background(), StatusStatePending, want.Description)
 
 	if diff := cmp.Diff(have, want); diff != "" {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,135 @@
+// Package logger provides a single logger for use by various GopherCI packages.
+//
+// It's designed to hide a single concrete logger from the various packages, it's
+// not designed to provide many logger alternatives to be swapped.
+package logger
+
+import (
+	"io"
+	"os"
+	"time"
+
+	"github.com/evalphobia/logrus_sentry"
+	"github.com/sirupsen/logrus"
+)
+
+// Logger is a service to write structured, levelled logs with context.
+type Logger interface {
+	// Debug level for developer concerned debugging, not visible in production.
+	Debug(args ...interface{})
+	Debugf(format string, args ...interface{})
+
+	// Info logs general events.
+	Info(args ...interface{})
+	Infof(format string, args ...interface{})
+
+	// Error logs, errors. An error should only be logged once.
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+
+	// Fatal logs an error and then immediately terminates execution.
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+
+	// With adds context to a logger.
+	With(name string, value interface{}) Logger
+}
+
+// Log implements the Logger interface by wrapping logrus.
+type log struct {
+	logrus *logrus.Entry
+}
+
+// New constructs a new Logger.
+func New(out io.Writer, build, env, sentryDSN string) Logger {
+	logger := logrus.New()
+	logger.Out = out
+	switch env {
+	case "production":
+		logger.Formatter = &logrus.JSONFormatter{}
+		logger.Level = logrus.InfoLevel
+	default:
+		logger.Formatter = &logrus.TextFormatter{}
+		logger.Level = logrus.DebugLevel
+	}
+
+	// server_name and logger have special meanings to logrus_sentry, to add that as a tag
+	ctxLogger := logger.WithField("logger", "gci")
+	if hostname, err := os.Hostname(); err == nil {
+		ctxLogger = ctxLogger.WithField("server_name", hostname)
+	}
+
+	if sentryDSN != "" {
+		hook, err := logrus_sentry.NewSentryHook(sentryDSN, []logrus.Level{
+			logrus.PanicLevel,
+			logrus.FatalLevel,
+			logrus.ErrorLevel,
+		})
+		hook.SetEnvironment(env)
+		hook.SetRelease(build)
+		hook.StacktraceConfiguration.Enable = true
+		hook.StacktraceConfiguration.Level = logrus.ErrorLevel // defaults to panic
+		hook.Timeout = 1 * time.Second                         // 100ms default is often too low
+		if err != nil {
+			logger.WithError(err).Fatal("could not setup sentry logrus")
+		}
+		logger.Hooks.Add(hook)
+		ctxLogger.WithField("area", "logger").Info("enabled sentry")
+	}
+
+	return &log{
+		logrus: ctxLogger,
+	}
+}
+
+// Testing returns a logger for use in tests.
+func Testing() Logger {
+	return New(os.Stdout, "", "testing", "")
+}
+
+// Debug implements the Logger interface.
+func (l *log) Debug(args ...interface{}) {
+	l.logrus.Debug(args...)
+}
+
+// Debugf implements the Logger interface.
+func (l *log) Debugf(format string, args ...interface{}) {
+	l.logrus.Debugf(format, args...)
+}
+
+// Info implements the Logger interface.
+func (l *log) Info(args ...interface{}) {
+	l.logrus.Info(args...)
+}
+
+// Infof implements the Logger interface.
+func (l *log) Infof(format string, args ...interface{}) {
+	l.logrus.Infof(format, args...)
+}
+
+// Error implements the Logger interface.
+func (l *log) Error(args ...interface{}) {
+	l.logrus.Error(args...)
+}
+
+// Errorf implements the Logger interface.
+func (l *log) Errorf(format string, args ...interface{}) {
+	l.logrus.Errorf(format, args...)
+}
+
+// Fatal implements the Logger interface.
+func (l *log) Fatal(args ...interface{}) {
+	l.logrus.Fatal(args...)
+}
+
+// Fatalf implements the Logger interface.
+func (l *log) Fatalf(format string, args ...interface{}) {
+	l.logrus.Fatalf(format, args...)
+}
+
+// With implements the Logger interface.
+func (l *log) With(key string, value interface{}) Logger {
+	return &log{
+		logrus: l.logrus.WithField(key, value),
+	}
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+)
+
+func TestLogger(t *testing.T) {
+
+	wantDevelopment := `time="" level=debug msg=debugarg logger=gci server_name= 
+time="" level=debug msg="debugf arg" logger=gci server_name= 
+time="" level=info msg=infoarg logger=gci server_name= 
+time="" level=info msg="infof arg" logger=gci server_name= 
+time="" level=error msg=errorarg logger=gci server_name= 
+time="" level=error msg="errorf arg" logger=gci server_name= 
+time="" level=info msg=context key=value logger=gci server_name= 
+`
+
+	wantProduction := `{"level":"info","logger":"gci","msg":"infoarg","server_name":"","time":""}
+{"level":"info","logger":"gci","msg":"infof arg","server_name":"","time":""}
+{"level":"error","logger":"gci","msg":"errorarg","server_name":"","time":""}
+{"level":"error","logger":"gci","msg":"errorf arg","server_name":"","time":""}
+{"key":"value","level":"info","logger":"gci","msg":"context","server_name":"","time":""}
+`
+
+	tests := map[string]struct {
+		env  string
+		want string
+	}{
+		"development": {env: "development", want: wantDevelopment},
+		"production":  {env: "production", want: wantProduction},
+	}
+
+	for desc, test := range tests {
+		var out bytes.Buffer
+
+		l := New(&out, "buildabc", test.env, "")
+
+		l.Debug("debug", "arg")
+		l.Debugf("debugf %s", "arg")
+
+		l.Info("info", "arg")
+		l.Infof("infof %s", "arg")
+
+		l.Error("error", "arg")
+		l.Errorf("errorf %s", "arg")
+
+		l.With("key", "value").Info("context")
+
+		have := out.String()
+		have = regexp.MustCompile(`time="[^"]+"`).ReplaceAllString(have, `time=""`)
+		have = regexp.MustCompile(`"time":"[^"]+"`).ReplaceAllString(have, `"time":""`)
+		have = regexp.MustCompile(`server_name=[a-zA-Z0-9.-]+`).ReplaceAllString(have, `server_name=`)
+		have = regexp.MustCompile(`"server_name":"[^"]+"`).ReplaceAllString(have, `"server_name":""`)
+
+		if have != test.want {
+			t.Errorf("desc: %s:\nhave:\n%swant:\n%s", desc, have, test.want)
+		}
+	}
+}

--- a/internal/queue/gcp-pubsub_test.go
+++ b/internal/queue/gcp-pubsub_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bradleyfalzon/gopherci/internal/logger"
 	"github.com/pkg/errors"
 )
 
@@ -27,7 +28,7 @@ func TestGCPPubSubQueue(t *testing.T) {
 		topic       = fmt.Sprintf("%s-unit-tests-%v", defaultTopicName, time.Now().Unix())
 		have        interface{}
 	)
-	q, err := NewGCPPubSubQueue(ctx, projectID, topic)
+	q, err := NewGCPPubSubQueue(ctx, logger.Testing(), projectID, topic)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -76,7 +77,7 @@ func TestGCPPubSubQueue_timeout(t *testing.T) {
 		ctx   = context.Background()
 		topic = fmt.Sprintf("%s-unit-tests-%v", defaultTopicName, time.Now().Unix())
 	)
-	_, err := NewGCPPubSubQueue(ctx, projectID, topic)
+	_, err := NewGCPPubSubQueue(ctx, logger.Testing(), projectID, topic)
 
 	have := errors.Cause(err)
 	if want := context.DeadlineExceeded; have != want {

--- a/internal/queue/memory_test.go
+++ b/internal/queue/memory_test.go
@@ -2,10 +2,11 @@ package queue
 
 import (
 	"context"
-	"log"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/bradleyfalzon/gopherci/internal/logger"
 )
 
 func TestMemoryQueue(t *testing.T) {
@@ -15,7 +16,7 @@ func TestMemoryQueue(t *testing.T) {
 		c           = make(chan interface{})
 		haveJob     bool
 	)
-	q := NewMemoryQueue()
+	q := NewMemoryQueue(logger.Testing())
 
 	f := func(interface{}) {
 		haveJob = true
@@ -24,9 +25,9 @@ func TestMemoryQueue(t *testing.T) {
 	q.Wait(ctx, &wg, c, f)
 	c <- 1
 
-	log.Println("waiting")
+	t.Log("waiting")
 	time.Sleep(pollInterval * 2)
-	log.Println("waited")
+	t.Log("waited")
 
 	if !haveJob {
 		t.Errorf("did not process job")


### PR DESCRIPTION
./internal/logger provides a single logger than all packages can use
to provide:

Levelled logs: Debug is for developers, Info for general production
messages to assist in troubleshooting, Error to be used when an error
occurs that's handled but needs to be raised to an operator and Fatal
which logs the message and terminates execution.

Structured: Using With() to add fields to a message allows operators to
easily view related messages, as GopherCI provides many concurrent
services, it's useful to only inspect message related to a certain
event.

Context: Using With() to return another Logger which logs all messages
with the provided name/key and value. Allows developers to pass along
loggers with information about the event so new clients can be unaware
of the event but still have additional context added to their logs.

Logger is its own interface that wraps a single type of logger. Currently
it is logrus, chosen because it matches requires, I'm familiar with it,
and supports hooks.

Sentry is also used for the hooks, where any event of level Error or
above will send the event to a Sentry instance, where operators can
collate, deduplicate be alerted and track resolutions.

Finally, due to case sensitive import conflicts of github.com/sirupsen/logrus
one of the copies is moved to the GOPATH to avoid conflicts with the other.
This is very unfortunate hack until everyone moves to lowercase the
import path.